### PR TITLE
Helm Chart: Fix to use official Postgresql Container image instead of Bitnami image

### DIFF
--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: {{ include "kubeclarity.name" . }}
       initContainers:
         - name: '{{ include "kubeclarity.name" . }}-wait-for-pg-db'
-          image: docker.io/bitnami/postgresql:{{ index .Values "kubeclarity-postgresql" "image" "tag" | default "11.16.0-debian-10-r23" }}
+          image: {{ index .Values "kubeclarity-postgresql" "image" "registry" | default "docker.io" }}/{{ index .Values "kubeclarity-postgresql" "image" "repository" | default "bitnami/postgresql" }}:{{ index .Values "kubeclarity-postgresql" "image" "tag" | default "11.16.0-debian-10-r23" }}
           command: ['sh', '-c', 'until pg_isready -h {{ include "kubeclarity.name" . }}-postgresql -p 5432 -U "postgres" -d "dbname={{ index .Values "kubeclarity-postgresql" "postgresqlDatabase" }}";
             do echo waiting for database; sleep 2; done;']
           securityContext:

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -225,6 +225,8 @@ kubeclarity-postgresql:
   ## imageTag is set to fix high/critical postgresql issues
   ## after https://github.com/bitnami/charts/issues/10661 issue is fixed the following lines can be commented out.
   image:
+    registry: docker.io
+    repository: bitnami/postgresql
     tag: 11.16.0-debian-10-r23
 
   ## ConfigMap with scripts to be run at first boot


### PR DESCRIPTION
This PR provides the option to use the official Postgres Container Image.
This requires a small change in deployment.yaml for the image of the initContainer.

How to use official Postgres image:

```yaml
kubeclarity-postgresql:

  # We use official Postgres image instead of Bitnami provided image as the Bitnami image has a lot of CVEs.
  # See https://docs.bitnami.com/kubernetes/infrastructure/postgresql/get-started/differences-docker-image/
  postgresqlDataDir: "/data/pgdata"
  persistence:
    mountPath: "/data"
  image:
    repository: postgres
    tag: 11.16-alpine3.16

  # Offical Postgres runs with user 70
  securityContext:
    enabled: true
    fsGroup: 70
  containerSecurityContext:
    enabled: true
    runAsUser: 70

```