### PR TITLE
Helm Chart: InitContainers: additional securityContext attributes and official curl image

### DIFF
--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -29,10 +29,13 @@ spec:
           {{- if not .Values.global.openShiftRestricted }}
             runAsUser: 1001
           {{- end }}
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           resources:
 {{- toYaml .Values.kubeclarity.initContainers.resources | nindent 12 }}
         - name: '{{ include "kubeclarity.name" . }}-wait-for-sbom-db'
-          image: yauritux/busybox-curl
+          image: curlimages/curl:7.84.0
           args:
             - /bin/sh
             - -c
@@ -49,11 +52,14 @@ spec:
           {{- if not .Values.global.openShiftRestricted }}
             runAsUser: 1001
           {{- end }}
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           resources:
 {{- toYaml .Values.kubeclarity.initContainers.resources | nindent 12 }}
 {{- if index .Values "kubeclarity-grype-server" "enabled" }}
         - name: '{{ include "kubeclarity.name" . }}-wait-for-grype-server'
-          image: yauritux/busybox-curl
+          image: curlimages/curl:7.84.0
           args:
             - /bin/sh
             - -c
@@ -70,6 +76,9 @@ spec:
           {{- if not .Values.global.openShiftRestricted }}
             runAsUser: 1001
           {{- end }}
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           resources:
 {{- toYaml .Values.kubeclarity.initContainers.resources | nindent 12 }}
 {{- end}}


### PR DESCRIPTION
This PR addresses three issues:

1. increase security by enforcing readonly filesystems in initcontainers and do not allow privilege escalation
2. Explicitly set `privileged: false` in order to be "compliant" to [kubeaudit](https://github.com/Shopify/kubeaudit) rules.
3. Use [official curl container image](https://hub.docker.com/r/curlimages/curl/tags) instead of [yauritux/busybox-curl](https://hub.docker.com/r/yauritux/busybox-curl)
    - official image instead of potential not-trustworthy source
    - Init containers run as uid=1001 while curl executable in `yauritux/busybox-curl` can only be run as root user. See file permissions from container: 
    
        ```
        $ docker run --rm -ti yauritux/busybox-curl /bin/sh
        /home # which curl
           /bin/curl
        /home # ls -las /bin/curl
           3376 -rwxr--r--    1 root     root       3455920 Jan 19 14:09 /bin/curl
        ```

        Here the file permissions for `curl` executable from official image 
        
        ```
        $ docker run --rm -ti curlimages/curl:7.84.0 /bin/sh
        / $ which curl
           /usr/bin/curl
        / $ ls -las /usr/bin/curl
           288 -rwxr-xr-x    1 root     root        293360 Jul  3 19:42 /usr/bin/curl
       ````