### PR TITLE
Fix (sbomdb): convert application log level to gorm logger level

### DIFF
--- a/sbom_db/backend/cmd/main.go
+++ b/sbom_db/backend/cmd/main.go
@@ -31,7 +31,8 @@ import (
 
 func run(c *cli.Context) {
 	logutils.InitLogs(c, os.Stdout)
-	backend.Run()
+	logLevel := c.String(logutils.LogLevelFlag)
+	backend.Run(logLevel)
 }
 
 func versionCommand(_ *cli.Context) {

--- a/sbom_db/backend/pkg/backend/run.go
+++ b/sbom_db/backend/pkg/backend/run.go
@@ -30,8 +30,8 @@ import (
 
 const defaultChanSize = 100
 
-func Run() {
-	config, err := _config.LoadConfig()
+func Run(logLevel string) {
+	config, err := _config.LoadConfig(logLevel)
 	if err != nil {
 		log.Errorf("Failed to load config: %v", err)
 		return
@@ -48,7 +48,7 @@ func Run() {
 
 	log.Info("KubeClarity SBOM DB backend is running")
 
-	dbHandler := database.InitDataBase()
+	dbHandler := database.InitDataBase(config.DBLogLevel)
 
 	if config.EnableFakeData {
 		go dbHandler.CreateFakeData()

--- a/sbom_db/backend/pkg/database/database.go
+++ b/sbom_db/backend/pkg/database/database.go
@@ -36,10 +36,10 @@ const (
 	localDBPath = "/tmp/db.db"
 )
 
-func InitDataBase() *Handler {
+func InitDataBase(logLevel logger.LogLevel) *Handler {
 	var db *gorm.DB
 	dbLogger := logger.Default
-	dbLogger = dbLogger.LogMode(logger.Info)
+	dbLogger = dbLogger.LogMode(logLevel)
 
 	db = initSqlite(dbLogger)
 


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

Use the application log level in the case of database logging as well.