### PR TITLE
Workaround issue processing scratch containers with no components in SBOM

### DIFF
--- a/e2e/cli_scan_test.go
+++ b/e2e/cli_scan_test.go
@@ -119,8 +119,8 @@ func getCdxSbom(t *testing.T, fileName string) *cdx.BOM {
 	t.Helper()
 	sbom, err := os.ReadFile(fileName)
 	assert.NilError(t, err)
-	input := formatter.New(formatter.CycloneDXFormat, sbom)
-	assert.NilError(t, input.Decode(formatter.CycloneDXFormat))
+	input := formatter.New(formatter.CycloneDXJSONFormat, sbom)
+	assert.NilError(t, input.Decode(formatter.CycloneDXJSONFormat))
 	return input.GetSBOM().(*cdx.BOM)
 }
 

--- a/shared/pkg/config/analyzer.go
+++ b/shared/pkg/config/analyzer.go
@@ -38,7 +38,7 @@ const (
 func setAnalyzerConfigDefaults() {
 	viper.SetDefault(AnalyzerList, []string{"syft", "gomod"})
 	viper.SetDefault(AnalyzerScope, "squashed")
-	viper.SetDefault(OutputFormat, formatter.CycloneDXFormat)
+	viper.SetDefault(OutputFormat, formatter.CycloneDXJSONFormat)
 }
 
 func LoadAnalyzerConfig() *Analyzer {

--- a/shared/pkg/formatter/cyclonedx.go
+++ b/shared/pkg/formatter/cyclonedx.go
@@ -16,7 +16,6 @@
 package formatter
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 
@@ -62,10 +61,9 @@ func (f *CycloneDX) GetSBOMBytes() []byte {
 
 func (f *CycloneDX) Encode(format string) error {
 	cdxFormat := getCycloneDXFormat(format)
-	var buff bytes.Buffer
-	outputWriter := bufio.NewWriter(&buff)
 
-	encoder := cdx.NewBOMEncoder(outputWriter, cdxFormat)
+	var buff bytes.Buffer
+	encoder := cdx.NewBOMEncoder(&buff, cdxFormat)
 	encoder.SetPretty(true)
 
 	if err := encoder.Encode(f.sbomStruct); err != nil {

--- a/shared/pkg/scanner/grype/common.go
+++ b/shared/pkg/scanner/grype/common.go
@@ -231,7 +231,7 @@ func parseLayerHex(layerID string) string {
 func getOriginalInputAndHashFromSBOM(inputSBOMFile string) (string, string, error) {
 	cdxBOM, err := converter.GetCycloneDXSBOMFromFile(inputSBOMFile)
 	if err != nil {
-		return "", "", converter.ErrFailedToGetCycloneDXSBOM
+		return "", "", fmt.Errorf("failed to get SBOM from file: %w", err)
 	}
 
 	hash, err := cdx_helper.GetComponentHash(cdxBOM.Metadata.Component)


### PR DESCRIPTION
When processing a scratch container with no dependencies the generated SBOM has no components. This PR adds a few commits that fix issues identified when trying to scan those SBOMs.