### PR TITLE
Improve analyzer SBOM merging

### DIFF
--- a/runtime_k8s_scanner/pkg/analyze/analyze.go
+++ b/runtime_k8s_scanner/pkg/analyze/analyze.go
@@ -55,7 +55,7 @@ func (a *AnalyzerImpl) Analyze(config *config.Config) (*analyzer.MergedResults, 
 	for name, result := range results {
 		a.logger.Infof("Merging result from %q", name)
 		if res, ok := result.(*analyzer.Results); ok {
-			mergedResults = mergedResults.Merge(res, config.SharedConfig.Analyzer.OutputFormat)
+			mergedResults = mergedResults.Merge(res)
 		} else {
 			a.logger.Errorf("Type assertion of result failed.")
 		}

--- a/shared/pkg/analyzer/analyzer.go
+++ b/shared/pkg/analyzer/analyzer.go
@@ -16,11 +16,13 @@
 package analyzer
 
 import (
+	cdx "github.com/CycloneDX/cyclonedx-go"
+
 	"github.com/openclarity/kubeclarity/shared/pkg/utils"
 )
 
 type Results struct {
-	Sbom         []byte
+	Sbom         *cdx.BOM
 	AnalyzerInfo string
 	AppInfo      AppInfo
 	Error        error
@@ -36,7 +38,7 @@ type AppInfo struct {
 	SourceHash string
 }
 
-func CreateResults(sbomBytes []byte, analyzerName, userInput string, srcType utils.SourceType) *Results {
+func CreateResults(sbomBytes *cdx.BOM, analyzerName, userInput string, srcType utils.SourceType) *Results {
 	return &Results{
 		Sbom:         sbomBytes,
 		AnalyzerInfo: analyzerName,

--- a/shared/pkg/analyzer/cdx_gomod/cyclonedx_gomod.go
+++ b/shared/pkg/analyzer/cdx_gomod/cyclonedx_gomod.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/openclarity/kubeclarity/shared/pkg/analyzer"
 	"github.com/openclarity/kubeclarity/shared/pkg/config"
-	"github.com/openclarity/kubeclarity/shared/pkg/formatter"
 	"github.com/openclarity/kubeclarity/shared/pkg/job_manager"
 	"github.com/openclarity/kubeclarity/shared/pkg/utils"
 )
@@ -98,20 +97,7 @@ func (a *Analyzer) Run(sourceType utils.SourceType, userInput string) error {
 		bom.Metadata.Tools = &[]cdx.Tool{*tool}
 		assertLicenses(bom)
 
-		// create the cycloneDX sbom
-		output := formatter.New(formatter.CycloneDXFormat, []byte{})
-		err = output.SetSBOM(bom)
-		if err != nil {
-			a.setError(res, fmt.Errorf("failed to set SBOM: %v", err))
-			return
-		}
-		// encode the cycloneDX sbom
-		if err := output.Encode(a.config.OutputFormat); err != nil {
-			a.setError(res, fmt.Errorf("failed to write results: %v", err))
-			return
-		}
-
-		res = analyzer.CreateResults(output.GetSBOMBytes(), a.name, userInput, sourceType)
+		res = analyzer.CreateResults(bom, a.name, userInput, sourceType)
 		a.logger.Infof("Sending successful results")
 		a.resultChan <- res
 	}()

--- a/shared/pkg/analyzer/merge.go
+++ b/shared/pkg/analyzer/merge.go
@@ -173,74 +173,85 @@ func mergeCDXComponent(mergedComponent, otherComponent cdx.Component, main bool)
 			mergedComponent.Version = otherComponent.Version
 		}
 	}
-	// BOMRef is only provided by the cycloneDX-gomod, need to check it before override it.
+
 	if mergedComponent.BOMRef == "" {
 		mergedComponent.BOMRef = otherComponent.BOMRef
 	}
-	// CPE is not porvided by the cycloneDX-gomod and sift at the moment.
+
 	if mergedComponent.CPE == "" {
 		mergedComponent.CPE = otherComponent.CPE
 	}
-	// Author isn't provided by cycloneDX-gomod and syft at the moment.
+
 	if mergedComponent.Author == "" {
 		mergedComponent.Author = otherComponent.Author
 	}
-	// Copyright isn't provided by cycloneDX-gomod and syft at the moment.
+
 	if mergedComponent.Copyright == "" {
 		mergedComponent.Copyright = otherComponent.Copyright
 	}
-	// Description can be provided by the cycloneDX-gomod.
+
 	if mergedComponent.Description == "" {
 		mergedComponent.Description = otherComponent.Description
 	}
-	// Evidence isn't provided by cycloneDX-gomod and syft at the moment.
+
 	if mergedComponent.Evidence == nil {
 		mergedComponent.Evidence = otherComponent.Evidence
 	}
-	// ExternalReferences are provided by the cycloneDX-gomod.
+
 	if mergedComponent.ExternalReferences == nil {
 		mergedComponent.ExternalReferences = otherComponent.ExternalReferences
 	}
-	// SWID isn't provided by cycloneDX-gomod and syft at the moment.
+
 	if mergedComponent.SWID == nil {
 		mergedComponent.SWID = otherComponent.SWID
 	}
-	// Supplier isn't provided by cycloneDX-gomod and syft at the moment.
+
 	if mergedComponent.Supplier == nil {
 		mergedComponent.Supplier = otherComponent.Supplier
 	}
-	// Publisher isn't provided by cycloneDX-gomod and syft at the moment.
+
 	if mergedComponent.Publisher == "" {
 		mergedComponent.Publisher = otherComponent.Publisher
 	}
-	// Group can be provided by only the cycloneDX-gomod.
+
 	if mergedComponent.Group == "" {
 		mergedComponent.Group = otherComponent.Group
 	}
-	// Scope can be provided by only the cycloneDX-gomod.
+
 	if mergedComponent.Scope == "" {
 		mergedComponent.Scope = otherComponent.Scope
 	}
-	// Hashes can be provided by only the cycloneDX-gomod.
+
 	if mergedComponent.Hashes == nil {
 		mergedComponent.Hashes = otherComponent.Hashes
 	}
-	// Licenses can be provided by only the cycloneDX-gomod.
-	if mergedComponent.Licenses == nil {
-		mergedComponent.Licenses = otherComponent.Licenses
-	}
-	// Properties can be provided by the syft and te cycloneDX-gomod, needs to be merged.
+
+	mergedComponent.Licenses = mergeLicenses(mergedComponent.Licenses, otherComponent.Licenses)
+
 	if otherComponent.Properties != nil {
 		mergedComponent.Properties = mergeProperties(mergedComponent.Properties, otherComponent.Properties)
 	}
-	// PackageURL in the case of cycloneDX-gomod contains type of the package as well.
-	// We use the longer PURL.
-	if len(mergedComponent.PackageURL) < len(otherComponent.PackageURL) {
-		mergedComponent.PackageURL = otherComponent.PackageURL
-	}
+
+	mergedComponent.PackageURL = mergePurlStrings(mergedComponent.PackageURL, otherComponent.PackageURL)
 	// Other unprovided fields: MIMEType, Supplier, Modified, Pedigree
 
 	return mergedComponent
+}
+
+func mergeLicenses(licenseA, licenseB *cdx.Licenses) *cdx.Licenses {
+	// nothing to merge into A so return the A untouched
+	if licenseB == nil {
+		return licenseA
+	}
+
+	// If A has no licenses initialise it
+	if licenseA == nil {
+		licenseA = &cdx.Licenses{}
+	}
+
+	// Merge B into A, assign to new variable to avoid modifying licenseA
+	newthing := append(*licenseA, *licenseB...)
+	return &newthing
 }
 
 func mergeProperties(properties, otherProperties *[]cdx.Property) *[]cdx.Property {

--- a/shared/pkg/analyzer/merge_test.go
+++ b/shared/pkg/analyzer/merge_test.go
@@ -23,9 +23,7 @@ import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"gotest.tools/assert"
 
-	"github.com/openclarity/kubeclarity/shared/pkg/formatter"
 	"github.com/openclarity/kubeclarity/shared/pkg/utils"
 )
 
@@ -271,12 +269,9 @@ func Test_handleComponentWithExistingKey(t *testing.T) {
 }
 
 func TestMergedResults_Merge(t *testing.T) {
-	otherFormatter := formatter.New(formatter.CycloneDXFormat, []byte{})
-	err := otherFormatter.SetSBOM(&cdx.BOM{
+	expectedSbom := &cdx.BOM{
 		Components: &[]cdx.Component{otherComponent, additionalComponent},
-	})
-	assert.NilError(t, err)
-	_ = otherFormatter.Encode(formatter.CycloneDXFormat)
+	}
 
 	type fields struct {
 		MergedComponentByKey map[componentKey]*MergedComponent
@@ -285,8 +280,7 @@ func TestMergedResults_Merge(t *testing.T) {
 		SourceHash           string
 	}
 	type args struct {
-		other  *Results
-		format string
+		other *Results
 	}
 	tests := []struct {
 		name   string
@@ -303,10 +297,9 @@ func TestMergedResults_Merge(t *testing.T) {
 			},
 			args: args{
 				other: &Results{
-					Sbom:         otherFormatter.GetSBOMBytes(),
+					Sbom:         expectedSbom,
 					AnalyzerInfo: "gomod",
 				},
-				format: formatter.CycloneDXFormat,
 			},
 			want: &MergedResults{
 				MergedComponentByKey: map[componentKey]*MergedComponent{
@@ -323,8 +316,8 @@ func TestMergedResults_Merge(t *testing.T) {
 				Source:               tt.fields.Source,
 				SrcMetaData:          tt.fields.SrcMetaData,
 			}
-			if got := m.Merge(tt.args.other, tt.args.format); !reflect.DeepEqual(got, tt.want) {
-				t.Logf("encoded %v\n", otherFormatter.GetSBOM())
+			if got := m.Merge(tt.args.other); !reflect.DeepEqual(got, tt.want) {
+				t.Logf("encoded %v\n", expectedSbom)
 				t.Errorf("Merge() = %v, want %v", got, tt.want)
 			}
 		})

--- a/shared/pkg/analyzer/purl.go
+++ b/shared/pkg/analyzer/purl.go
@@ -1,0 +1,174 @@
+// Copyright © 2022 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzer
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type purl struct {
+	scheme    string
+	typ       string
+	namespace string
+	name      string
+	version   string
+	qualifers url.Values
+	subpath   string
+}
+
+func (p purl) String() string {
+	opaque := p.typ
+	if p.namespace != "" {
+		opaque = fmt.Sprintf("%s/%s", opaque, p.namespace)
+	}
+	opaque = fmt.Sprintf("%s/%s@%s", opaque, p.name, p.version)
+
+	pURL := url.URL{
+		Scheme:   p.scheme,
+		Opaque:   opaque,
+		RawQuery: p.qualifers.Encode(),
+		Fragment: p.subpath,
+	}
+
+	return pURL.String()
+}
+
+func newPurl() purl {
+	return purl{
+		qualifers: url.Values{},
+	}
+}
+
+var validPurlTypes = map[string]struct{}{
+	"alpm":        {},
+	"apk":         {},
+	"bitbucket":   {},
+	"cocoapods":   {},
+	"cargo":       {},
+	"composer":    {},
+	"conan":       {},
+	"conda":       {},
+	"cran":        {},
+	"deb":         {},
+	"docker":      {},
+	"gem":         {},
+	"generic":     {},
+	"github":      {},
+	"golang":      {},
+	"hackage":     {},
+	"hex":         {},
+	"huggingface": {},
+	"maven":       {},
+	"mlflow":      {},
+	"npm":         {},
+	"nuget":       {},
+	"qpkg":        {},
+	"oci":         {},
+	"pub":         {},
+	"pypi":        {},
+	"rpm":         {},
+	"swid":        {},
+	"swift":       {},
+}
+
+func purlStringToStruct(purlInput string) purl {
+	if purlInput == "" {
+		return newPurl()
+	}
+
+	purlURL, err := url.Parse(purlInput)
+	if err != nil {
+		// Not a valid purl so return empty
+		return newPurl()
+	}
+
+	output := purl{
+		scheme:    purlURL.Scheme,
+		qualifers: purlURL.Query(),
+		subpath:   purlURL.Fragment,
+	}
+
+	purlParts := strings.Split(purlURL.Opaque, "/")
+
+	// nolint:gomnd
+	if len(purlParts) == 2 {
+		// Check type sometimes the anaylzers goof up and forget the
+		// type part, looking at you syft....
+		if _, ok := validPurlTypes[purlParts[0]]; ok {
+			output.typ = purlParts[0]
+		} else {
+			// Fix known cases otherwise just exclude the type from
+			// the purl or error maybe, havn't decided
+			if purlParts[0] == "alpine" {
+				output.typ = "apk"
+				output.namespace = "alpine"
+			}
+		}
+	} else {
+		output.typ = purlParts[0]
+		output.namespace = purlParts[1]
+	}
+
+	name, version, _ := strings.Cut(purlParts[len(purlParts)-1], "@")
+	output.name = name
+	output.version = version
+
+	return output
+}
+
+func mergePurl(purlA, purlB purl) purl {
+	if purlA.scheme == "" {
+		purlA.scheme = purlB.scheme
+	}
+
+	if purlA.typ == "" {
+		purlA.typ = purlB.typ
+	}
+
+	if purlA.namespace == "" {
+		purlA.namespace = purlB.namespace
+	}
+
+	if purlA.name == "" {
+		purlA.name = purlB.name
+	}
+
+	if purlA.version == "" {
+		purlA.version = purlB.version
+	}
+
+	for key := range purlB.qualifers {
+		if purlA.qualifers.Has(key) {
+			continue
+		}
+		purlA.qualifers.Set(key, purlB.qualifers.Get(key))
+	}
+
+	if purlA.subpath == "" {
+		purlA.subpath = purlB.subpath
+	}
+
+	return purlA
+}
+
+func mergePurlStrings(purlAStr, purlBStr string) string {
+	purlA := purlStringToStruct(purlAStr)
+	purlB := purlStringToStruct(purlBStr)
+	purlC := mergePurl(purlA, purlB)
+	return purlC.String()
+}

--- a/shared/pkg/analyzer/syft/syft.go
+++ b/shared/pkg/analyzer/syft/syft.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/anchore/syft/syft"
 	syft_artifact "github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/formats/common/cyclonedxhelpers"
 	"github.com/anchore/syft/syft/linux"
 	syft_pkg "github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/pkg/cataloger"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/openclarity/kubeclarity/shared/pkg/analyzer"
 	"github.com/openclarity/kubeclarity/shared/pkg/config"
-	"github.com/openclarity/kubeclarity/shared/pkg/formatter"
 	"github.com/openclarity/kubeclarity/shared/pkg/job_manager"
 	"github.com/openclarity/kubeclarity/shared/pkg/utils"
 	"github.com/openclarity/kubeclarity/shared/pkg/utils/image_helper"
@@ -82,19 +82,11 @@ func (a *Analyzer) Run(sourceType utils.SourceType, userInput string) error {
 			a.setError(res, fmt.Errorf("failed to write results: %v", err))
 			return
 		}
-
-		output := formatter.New(formatter.SyftFormat, []byte{})
 		sbom := generateSBOM(p, r, d, s)
-		if err := output.SetSBOM(sbom); err != nil {
-			a.setError(res, fmt.Errorf("failed to set SBOM struct in formatter: %v", err))
-			return
-		}
-		if err := output.Encode(a.config.OutputFormat); err != nil {
-			a.setError(res, fmt.Errorf("failed to write results: %v", err))
-			return
-		}
 
-		res = analyzer.CreateResults(output.GetSBOMBytes(), a.name, src, sourceType)
+		cdxBom := cyclonedxhelpers.ToFormatModel(sbom)
+		res = analyzer.CreateResults(cdxBom, a.name, src, sourceType)
+
 		// Syft uses ManifestDigest to fill version information in the case of an image.
 		// We need RepoDigest as well which is not set by Syft if we using cycloneDX output.
 		// Get the RepoDigest from image metadata and use it as SourceHash in the Result

--- a/shared/pkg/config/gomod.go
+++ b/shared/pkg/config/gomod.go
@@ -15,12 +15,8 @@
 
 package config
 
-type GomodConfig struct {
-	OutputFormat string
-}
+type GomodConfig struct{}
 
 func ConvertToGomodConfig(analyzer *Analyzer) GomodConfig {
-	return GomodConfig{
-		OutputFormat: analyzer.OutputFormat,
-	}
+	return GomodConfig{}
 }

--- a/shared/pkg/config/syft.go
+++ b/shared/pkg/config/syft.go
@@ -22,14 +22,12 @@ import (
 
 // TODO: maybe we need to extend syft confg.
 type SyftConfig struct {
-	OutputFormat    string
 	Scope           source.Scope
 	RegistryOptions *image.RegistryOptions
 }
 
 func CreateSyftConfig(analyzer *Analyzer, registry *Registry) SyftConfig {
 	return SyftConfig{
-		OutputFormat:    analyzer.OutputFormat,
 		Scope:           source.ParseScope(analyzer.Scope),
 		RegistryOptions: CreateRegistryOptions(registry),
 	}

--- a/shared/pkg/config/trivy.go
+++ b/shared/pkg/config/trivy.go
@@ -42,16 +42,14 @@ func LoadAnalyzerTrivyConfig() AnalyzerTrivyConfig {
 }
 
 type AnalyzerTrivyConfigEx struct {
-	OutputFormat string
-	Timeout      time.Duration
-	Registry     *Registry
+	Timeout  time.Duration
+	Registry *Registry
 }
 
 func CreateAnalyzerTrivyConfigEx(analyzer *Analyzer, registry *Registry) AnalyzerTrivyConfigEx {
 	return AnalyzerTrivyConfigEx{
-		OutputFormat: analyzer.OutputFormat,
-		Timeout:      time.Duration(analyzer.TrivyConfig.Timeout) * time.Second,
-		Registry:     registry,
+		Timeout:  time.Duration(analyzer.TrivyConfig.Timeout) * time.Second,
+		Registry: registry,
 	}
 }
 


### PR DESCRIPTION
This PR includes several commits to improve the analyzer SBOM merging logic, removing the need for extra encode/decode operations, and also handling some of the more complex fields in the components so that information isn't lost during the merge.