### PR TITLE
Fix regression on cyclonedx JSON format

### DIFF
--- a/shared/pkg/converter/cyclonedx.go
+++ b/shared/pkg/converter/cyclonedx.go
@@ -37,11 +37,11 @@ const (
 )
 
 func (c SbomFormat) String() string {
-	strings := []string{"cyclonedx-json", "cyclonedx-xml", "spdx-json", "spdx-keyvalue", "syft"}
-	if c > Unknown && int(c) < len(strings) {
-		return strings[c]
+	strings := []string{"unknown", "cyclonedx-json", "cyclonedx-xml", "spdx-json", "spdx-keyvalue", "syft"}
+	if int(c) >= len(strings) {
+		return "unknown"
 	}
-	return "unknown"
+	return strings[c]
 }
 
 func StringToSbomFormat(input string) (SbomFormat, error) {


### PR DESCRIPTION
A bug in the format enum String() function resulted in the default output format being cyclonedx-xml instead of cyclonedx-json. This commit fixes that bug.