### PR TITLE
helm: adding the possibility to create an ingress

### DIFF
--- a/charts/kubeclarity/templates/_helpers.tpl
+++ b/charts/kubeclarity/templates/_helpers.tpl
@@ -48,3 +48,18 @@ Helm labels.
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 {{- end -}}
+
+{{/*
+Sets extra ingress annotations
+*/}}
+{{- define "kubeclarity.ingress.annotations" -}}
+  {{- if .Values.kubeclarity.ingress.annotations }}
+  annotations:
+    {{- $tp := typeOf .Values.kubeclarity.ingress.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.kubeclarity.ingress.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.kubeclarity.ingress.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/charts/kubeclarity/templates/_helpers.tpl
+++ b/charts/kubeclarity/templates/_helpers.tpl
@@ -63,3 +63,17 @@ Sets extra ingress annotations
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Sets extra Kubeclarity server Service annotations
+*/}}
+{{- define "kubeclarity.service.annotations" -}}
+  {{- if .Values.kubeclarity.service.annotations }}
+    {{- $tp := typeOf .Values.kubeclarity.service.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.kubeclarity.service.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.kubeclarity.service.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/charts/kubeclarity/templates/ingress.yaml
+++ b/charts/kubeclarity/templates/ingress.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.kubeclarity.ingress.enabled -}}
+{{- $kubeVersion := .Capabilities.KubeVersion.Version }}
+{{- $pathType := .Values.kubeclarity.ingress.pathType -}}
+{{- $serviceName := include "kubeclarity.name" . -}}
+{{- $servicePort := .Values.kubeclarity.service.port -}}
+{{ if semverCompare ">= 1.19.0-0" $kubeVersion }}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end }}
+kind: Ingress
+metadata:
+  name: {{ include "kubeclarity.name" . }}
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+    {{ include "kubeclarity.labels" . }}
+  {{- template "kubeclarity.ingress.annotations" . }}
+spec:
+{{- if .Values.kubeclarity.ingress.tls }}
+  tls:
+  {{- range .Values.kubeclarity.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+{{- if .Values.kubeclarity.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.kubeclarity.ingress.ingressClassName }}
+{{- end }}
+  rules:
+  {{- range .Values.kubeclarity.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range (.paths | default (list "/")) }}
+          - path: {{ . -}}
+            {{- if semverCompare ">= 1.19.0-0" $kubeVersion }}
+            pathType: {{ $pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">= 1.19.0-0" $kubeVersion }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+              {{ else }}
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+              {{ end }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/kubeclarity/templates/ingress.yaml
+++ b/charts/kubeclarity/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.kubeclarity.ingress.enabled -}}
 {{- $kubeVersion := .Capabilities.KubeVersion.Version }}
-{{- $pathType := .Values.kubeclarity.ingress.pathType -}}
 {{- $serviceName := include "kubeclarity.name" . -}}
 {{- $servicePort := 8080 -}}
 {{ if semverCompare ">= 1.19.0-0" $kubeVersion }}
@@ -36,10 +35,10 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range (.paths | default (list "/")) }}
-          - path: {{ . -}}
+        {{- range (.paths | default (list (dict "pathType" "Prefix" "path" "/"))) }}
+          - path: {{ .path -}}
             {{- if semverCompare ">= 1.19.0-0" $kubeVersion }}
-            pathType: {{ $pathType }}
+            pathType: {{ .pathType }}
             {{- end }}
             backend:
               {{- if semverCompare ">= 1.19.0-0" $kubeVersion }}

--- a/charts/kubeclarity/templates/ingress.yaml
+++ b/charts/kubeclarity/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $kubeVersion := .Capabilities.KubeVersion.Version }}
 {{- $pathType := .Values.kubeclarity.ingress.pathType -}}
 {{- $serviceName := include "kubeclarity.name" . -}}
-{{- $servicePort := .Values.kubeclarity.service.port -}}
+{{- $servicePort := 8080 -}}
 {{ if semverCompare ">= 1.19.0-0" $kubeVersion }}
 apiVersion: networking.k8s.io/v1
 {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}

--- a/charts/kubeclarity/templates/service.yaml
+++ b/charts/kubeclarity/templates/service.yaml
@@ -7,6 +7,7 @@ metadata:
     {{ include "kubeclarity.labels" . }}
   annotations:
     helm.sh/hook: pre-install
+{{ template "kubeclarity.service.annotations" .}}
 spec:
   type: {{ .Values.kubeclarity.service.type }}
   ports:

--- a/charts/kubeclarity/templates/service.yaml
+++ b/charts/kubeclarity/templates/service.yaml
@@ -12,9 +12,9 @@ spec:
   type: {{ .Values.kubeclarity.service.type }}
   ports:
     - name: backend
-      port: 8080
+      port: {{ index .Values "kubeclarity" "service" "port" }}
       protocol: TCP
-      targetPort: 8080
+      targetPort: {{ index .Values "kubeclarity" "service" "targetPort" }}
     - name: runtime-scan-results
       port: {{ index .Values "kubeclarity-runtime-scan" "resultServicePort" }}
       protocol: TCP

--- a/charts/kubeclarity/templates/service.yaml
+++ b/charts/kubeclarity/templates/service.yaml
@@ -12,9 +12,9 @@ spec:
   type: {{ .Values.kubeclarity.service.type }}
   ports:
     - name: backend
-      port: {{ index .Values "kubeclarity" "service" "port" }}
+      port: 8080
       protocol: TCP
-      targetPort: {{ index .Values "kubeclarity" "service" "targetPort" }}
+      targetPort: 8080
     - name: runtime-scan-results
       port: {{ index .Values "kubeclarity-runtime-scan" "resultServicePort" }}
       protocol: TCP

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -58,7 +58,7 @@ kubeclarity:
     annotations: {}
 
   ingress:
-    # Be careful when using ingress. As there is no authentication on Kubeclarity yet, Your instance may be accessible. 
+    # Be careful when using ingress. As there is no authentication on Kubeclarity yet, your instance may be accessible. 
     # Make sure the ingress remains internal if you decide to enable it.
     enabled: false
     labels: {}
@@ -71,10 +71,11 @@ kubeclarity:
     hosts:
         # hostname you want to use
       - host: chart-example.local
-        # path will default to /
+        # paths will default to:
+        # paths:
+        #   - pathType: Prefix
+        #     path: /
         paths: []
-        #  - pathType: Prefix
-        #    path: ["/foo"]
 
     tls: []
     #  - secretName: chart-example-tls

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -55,6 +55,10 @@ kubeclarity:
 
   service:
     type: ClusterIP
+    # Port on which Kubeclarity server is listening
+    port: 8080
+    # Target port to which the service should be mapped to
+    targetPort: 8080
 
   ## In case of postgres refresh interval of refreshing materialized views in seconds
   # dbViewRefreshInterval: 5

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -68,15 +68,14 @@ kubeclarity:
     # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
     ingressClassName: ""
 
-    # As of Kubernetes 1.19, all Ingress Paths must have a pathType configured. The default value below should be sufficient in most cases.
-    # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types for other possible values.
-    pathType: Prefix
-
     hosts:
         # hostname you want to use
       - host: chart-example.local
         # path will default to /
         paths: []
+        #  - pathType: Prefix
+        #    path: ["/foo"]
+
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -62,6 +62,8 @@ kubeclarity:
     targetPort: 8080
 
   ingress:
+    # Be careful when using ingress. As there is no authentication on Kubeclarity yet, Your instance may be accessible. 
+    # Make sure the ingress remains internal if you decide to enable it.
     enabled: false
     labels: {}
     annotations: {}

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -55,6 +55,7 @@ kubeclarity:
 
   service:
     type: ClusterIP
+    annotations: {}
     # Port on which Kubeclarity server is listening
     port: 8080
     # Target port to which the service should be mapped to

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -58,7 +58,7 @@ kubeclarity:
     annotations: {}
 
   ingress:
-    # Be careful when using ingress. As there is no authentication on Kubeclarity yet, your instance may be accessible. 
+    # Be careful when using ingress. As there is no authentication on Kubeclarity yet, your instance may be accessible.
     # Make sure the ingress remains internal if you decide to enable it.
     enabled: false
     labels: {}

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -56,10 +56,6 @@ kubeclarity:
   service:
     type: ClusterIP
     annotations: {}
-    # Port on which Kubeclarity server is listening
-    port: 8080
-    # Target port to which the service should be mapped to
-    targetPort: 8080
 
   ingress:
     # Be careful when using ingress. As there is no authentication on Kubeclarity yet, Your instance may be accessible. 

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -60,6 +60,29 @@ kubeclarity:
     # Target port to which the service should be mapped to
     targetPort: 8080
 
+  ingress:
+    enabled: false
+    labels: {}
+    annotations: {}
+
+    # Optionally use ingressClassName instead of deprecated annotation.
+    # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+    ingressClassName: ""
+
+    # As of Kubernetes 1.19, all Ingress Paths must have a pathType configured. The default value below should be sufficient in most cases.
+    # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types for other possible values.
+    pathType: Prefix
+
+    hosts:
+        # hostname you want to use
+      - host: chart-example.local
+        # path will default to /
+        paths: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
   ## In case of postgres refresh interval of refreshing materialized views in seconds
   # dbViewRefreshInterval: 5
 


### PR DESCRIPTION
Hello everyone. 

I know there is no authentication yet on Kubeclarity, but I needed an ingress to be able to reach my Kubeclarity instance through an hostname, only reachable when connected to a VPN.

I tried to make retrocompatible changes and it shouldn't impact current helm deployments.

I tried this on my side (GKE) and can now:
- Access the UI with an hostname
- Access the backend in my CI/CD pipelines through the hostname

On my environment, a VPN is needed to reach the Kubeclarity instance.

Please let me know modifications I may have to make. 

Thanks everyone for your comments.