### PR TITLE
Improve Docker build performance when re-running builds

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.2
 FROM node:19-slim AS site-build
 
 WORKDIR /app/ui-build
@@ -6,54 +7,40 @@ COPY ui .
 RUN npm i
 RUN npm run build
 
-
 FROM golang:1.19.4-alpine AS builder
 
-ARG VERSION
-ARG BUILD_TIMESTAMP
-ARG COMMIT_HASH
+RUN apk add --update --no-cache gcc g++ git ca-certificates build-base
 
-RUN apk add --update --no-cache gcc g++ git
+# Copy API code
+WORKDIR /build/api
+COPY api .
 
-# Copy api code
-WORKDIR /build
-COPY api ./api
-
-# Copy runtime_scan go.mod & go.sum & api code
+# Copy runtime_scan code including runtime_scan/api code
 WORKDIR /build/runtime_scan
-COPY runtime_scan/go.* ./
-COPY runtime_scan/api ./api
-
-# Copy runtime_k8s_scanner go.mod & go.sum
-WORKDIR /build/runtime_k8s_scanner
-COPY runtime_k8s_scanner/go.* ./
-
-# Copy shared go.mod & go.sum
-WORKDIR /build/shared
-COPY shared/go.* ./
-RUN go mod download
-
-# Copy backend go.mod & go.sum
-WORKDIR /build/backend
-COPY backend/go.* ./
-RUN go mod download
-
-# Copy runtime_scan code
-WORKDIR /build
-COPY runtime_scan ./runtime_scan
+COPY runtime_scan .
 
 # Copy runtime_k8s_scanner code
-WORKDIR /build
-COPY runtime_k8s_scanner ./runtime_k8s_scanner
+WORKDIR /build/runtime_k8s_scanner
+COPY runtime_k8s_scanner .
 
 # Copy shared code
 WORKDIR /build/shared
 COPY shared .
 
-# Copy and build backend code
+# Copy backend code
 WORKDIR /build/backend
 COPY backend .
-RUN go build -ldflags="-s -w \
+
+# Build backend code
+# NOTE(sambetts) Declare ARGs where they are used to prevent Docker rerunning
+# all the previous steps when they change, and use buildkit inline cache to
+# keep go mod cache and compilation cache between docker runs.
+ARG VERSION
+ARG BUILD_TIMESTAMP
+ARG COMMIT_HASH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w \
      -X 'github.com/openclarity/kubeclarity/backend/pkg/version.Version=${VERSION}' \
      -X 'github.com/openclarity/kubeclarity/backend/pkg/version.CommitHash=${COMMIT_HASH}' \
      -X 'github.com/openclarity/kubeclarity/backend/pkg/version.BuildTimestamp=${BUILD_TIMESTAMP}'" -o backend ./cmd/backend/main.go

--- a/Dockerfile.cis_docker_benchmark_scanner
+++ b/Dockerfile.cis_docker_benchmark_scanner
@@ -1,28 +1,38 @@
+# syntax=docker/dockerfile:1.2
 FROM golang:1.19.4-alpine AS builder
 
-ARG VERSION
-ARG BUILD_TIMESTAMP
-ARG COMMIT_HASH
-
-RUN apk add --update --no-cache gcc g++ git ca-certificates
-
-# Copy runtime scan api code
-WORKDIR /build/runtime_scan
-COPY runtime_scan/api ./api
+RUN apk add --update --no-cache gcc g++ git ca-certificates build-base
 
 # Copy shared code
 WORKDIR /build/shared
 COPY shared .
 
-# Copy cis docker benchmark scanner go.mod & go.sum
-WORKDIR /build/cis_docker_benchmark_scanner
-COPY cis_docker_benchmark_scanner/go.* ./
-RUN go mod download
+# Copy sbom db api code
+WORKDIR /build/sbom_db/api
+COPY sbom_db/api .
 
-# Copy and build cis docker benchmark scanner code
+# Copy runtime_k8s_scanner code
+WORKDIR /build/runtime_k8s_scanner
+COPY runtime_k8s_scanner .
+
+# Copy runtime scan api code
+WORKDIR /build/runtime_scan/api
+COPY runtime_scan/api .
+
+# Copy cis docker benchmark scanner code
 WORKDIR /build/cis_docker_benchmark_scanner
 COPY cis_docker_benchmark_scanner .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w \
+
+# Build cis docker benchmark scanner code
+# NOTE(sambetts) Declare ARGs where they are used to prevent Docker rerunning
+# all the previous steps when they change, and use buildkit inline cache to
+# keep go mod cache and compilation cache between docker runs.
+ARG VERSION
+ARG BUILD_TIMESTAMP
+ARG COMMIT_HASH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -ldflags="-s -w \
      -X 'github.com/openclarity/kubeclarity/cis_docker_benchmark_scanner/pkg/version.Version=${VERSION}' \
      -X 'github.com/openclarity/kubeclarity/cis_docker_benchmark_scanner/pkg/version.CommitHash=${COMMIT_HASH}' \
      -X 'github.com/openclarity/kubeclarity/cis_docker_benchmark_scanner/pkg/version.BuildTimestamp=${BUILD_TIMESTAMP}'" \

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,33 +1,29 @@
+# syntax=docker/dockerfile:1.2
 FROM golang:1.19.4-alpine AS builder
 
-ARG COMMIT_HASH
+RUN apk add --update --no-cache gcc g++ git ca-certificates build-base
 
-RUN apk add --update --no-cache ca-certificates git
-RUN apk add build-base
-
+# Copy API code
 WORKDIR /build
 COPY api ./api
-
-# Copy shared go.mod & go.sum
-WORKDIR /build/shared
-COPY shared/go.* ./
-RUN go mod download
-
-# Copy cli go.mod & go.sum
-WORKDIR /build/cli
-COPY cli/go.* ./
-RUN go mod download
 
 # Copy shared code
 WORKDIR /build/shared
 COPY shared .
 
-# Copy and build cli code
+# Copy CLI code
 WORKDIR /build/cli
 COPY cli .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w \
+
+# Build CLI code
+# NOTE(sambetts) Declare ARGs where they are used to prevent Docker rerunning
+# all the previous steps when they change, and use buildkit inline cache to
+# keep go mod cache and compilation cache between docker runs.
+ARG COMMIT_HASH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -ldflags="-s -w \
      -X 'github.com/openclarity/kubeclarity/cli/pkg.GitRevision=${COMMIT_HASH}'" -o cli ./main.go
-RUN CGO_ENABLED=0 go build -ldflags "${LDFLAGS}"  ./...
 
 FROM alpine:3.17
 

--- a/Dockerfile.runtime_k8s_scanner
+++ b/Dockerfile.runtime_k8s_scanner
@@ -1,37 +1,34 @@
+# syntax=docker/dockerfile:1.2
 FROM golang:1.19.4-alpine AS builder
 
-ARG VERSION
-ARG BUILD_TIMESTAMP
-ARG COMMIT_HASH
-
-RUN apk add --update --no-cache gcc g++ git
+RUN apk add --update --no-cache gcc g++ git ca-certificates build-base
 
 # Copy runtime scan api code
-WORKDIR /build/runtime_scan
-COPY runtime_scan/api ./api
+WORKDIR /build/runtime_scan/api
+COPY runtime_scan/api .
 
 # Copy sbom db api code
 WORKDIR /build/sbom_db
 COPY sbom_db/api ./api
 
-# Copy shared go.mod & go.sum
-WORKDIR /build/shared
-COPY shared/go.* ./
-RUN go mod download
-
-# Copy scanner go.mod & go.sum
-WORKDIR /build/runtime_k8s_scanner
-COPY runtime_k8s_scanner/go.* ./
-RUN go mod download
-
 # Copy shared code
 WORKDIR /build/shared
 COPY shared .
 
-# Copy and build scanner code
+# Copy scanner code
 WORKDIR /build/runtime_k8s_scanner
 COPY runtime_k8s_scanner .
-RUN go build -ldflags="-s -w \
+
+# Build scanner code
+# NOTE(sambetts) Declare ARGs where they are used to prevent Docker rerunning
+# all the previous steps when they change, and use buildkit inline cache to
+# keep go mod cache and compilation cache between docker runs.
+ARG VERSION
+ARG BUILD_TIMESTAMP
+ARG COMMIT_HASH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w \
      -X 'github.com/openclarity/kubeclarity/runtime_k8s_scanner/pkg/version.Version=${VERSION}' \
      -X 'github.com/openclarity/kubeclarity/runtime_k8s_scanner/pkg/version.CommitHash=${COMMIT_HASH}' \
      -X 'github.com/openclarity/kubeclarity/runtime_k8s_scanner/pkg/version.BuildTimestamp=${BUILD_TIMESTAMP}'" \

--- a/Dockerfile.sbom_db
+++ b/Dockerfile.sbom_db
@@ -1,21 +1,26 @@
+# syntax=docker/dockerfile:1.2
 FROM golang:1.19.4-alpine AS builder
 
-RUN apk add --update --no-cache gcc g++ git
+RUN apk add --update --no-cache gcc g++ git ca-certificates build-base
 
+# Copy sbom db api code
 WORKDIR /build/sbom_db
 COPY sbom_db/api ./api
 
+# Copy sbom db code
 WORKDIR /build/sbom_db/backend
-COPY sbom_db/backend/go.* ./
-RUN go mod download
+COPY sbom_db/backend .
 
+# Build sbom DB code
+# NOTE(sambetts) Declare ARGs where they are used to prevent Docker rerunning
+# all the previous steps when they change, and use buildkit inline cache to
+# keep go mod cache and compilation cache between docker runs.
 ARG VERSION
 ARG BUILD_TIMESTAMP
 ARG COMMIT_HASH
-
-# Copy and build backend code
-COPY sbom_db/backend .
-RUN go build -ldflags="-s -w \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w \
      -X 'github.com/openclarity/kubeclarity/sbom_db/backend/pkg/version.Version=${VERSION}' \
      -X 'github.com/openclarity/kubeclarity/sbom_db/backend/pkg/version.CommitHash=${COMMIT_HASH}' \
      -X 'github.com/openclarity/kubeclarity/sbom_db/backend/pkg/version.BuildTimestamp=${BUILD_TIMESTAMP}'" -o sbom_db ./cmd/main.go


### PR DESCRIPTION
Moving the docker ARG directives to where they are required prevents docker re-evaulating all the steps in the Dockerfile when the args change.

Adding Dockerfile buildkit caches to the go build step prevents the need for go to recompile everything on every build, and also removes the need to put separate layers for `go mod download`.
https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mount

Without this PR:
`make docker` on a fresh system (docker system prune -a): 38 mins
`make docker` again with a small edit in shared/: 35 mins

With this PR:
`make docker` on a fresh system: 14mins
`make docker` again with a small edit in shared/: 1 min 30 seconds