### PR TITLE
Fix issue filtering on ApplicationID with no packages or vuls

### DIFF
--- a/backend/pkg/database/common.go
+++ b/backend/pkg/database/common.go
@@ -88,7 +88,7 @@ func FilterIsBool(db *gorm.DB, column string, value *bool) *gorm.DB {
 }
 
 func FilterIs(db *gorm.DB, column string, values []string) *gorm.DB {
-	if len(values) == 0 {
+	if values == nil {
 		return db
 	}
 	return db.Where(fmt.Sprintf("%s IN ?", column), values)

--- a/backend/pkg/database/id_view.go
+++ b/backend/pkg/database/id_view.go
@@ -55,10 +55,12 @@ type IDsViewHandler struct {
 }
 
 func (i *IDsViewHandler) GetIDs(params GetIDsParams, idsShouldMatch bool) ([]string, error) {
-	var ids []string
+	ids := []string{}
 
 	if len(params.FilterIDs) == 0 {
-		// nothing to filter by
+		// nothing to filter by, so return nil so that the caller knows
+		// the difference between a query wasn't made, and there were
+		// no results
 		return nil, nil
 	}
 
@@ -91,9 +93,10 @@ func (i *IDsViewHandler) GetIDs(params GetIDsParams, idsShouldMatch bool) ([]str
 		return nil, fmt.Errorf("failed to count IDs: %v", err)
 	}
 	if count <= 0 {
-		// No need to run query.
+		// No need to run query, but return empty list of strings
+		// because there are no results, not nil
 		log.Debugf("no IDs found. pararms=%+v", params)
-		return nil, nil
+		return ids, nil
 	}
 
 	// Run query.


### PR DESCRIPTION
If an Application has no vulnerabilties or packages, when filtering on that ApplicationID through the API, the API would return everything instead of filtering to nothing. This ensures that if you filter on ApplicationID which doesn't match anything, then the API returns no results.