### PR TITLE
Use trivy vul References instead of PrimaryURL

### DIFF
--- a/shared/pkg/scanner/trivy/scanner.go
+++ b/shared/pkg/scanner/trivy/scanner.go
@@ -308,16 +308,16 @@ func (a *Scanner) CreateResult(trivyJSON []byte, hash string) *scanner.Results {
 				distro.Version = report.Metadata.OS.Name
 			}
 
+			links := make([]string, 0, len(vul.Vulnerability.References))
+			links = append(links, vul.Vulnerability.References...)
 			kbVul := scanner.Vulnerability{
 				ID:          vul.VulnerabilityID,
 				Description: vul.Description,
-				Links: []string{
-					vul.PrimaryURL,
-				},
-				Distro:   distro,
-				CVSS:     cvsses,
-				Fix:      fix,
-				Severity: strings.ToUpper(vul.Severity),
+				Links:       links,
+				Distro:      distro,
+				CVSS:        cvsses,
+				Fix:         fix,
+				Severity:    strings.ToUpper(vul.Severity),
 				Package: scanner.Package{
 					Name:    vul.PkgName,
 					Version: vul.InstalledVersion,


### PR DESCRIPTION
trivy PrimaryURL is a link to avd.aquasec.com, which aggregates links we already have in vul.Vulnerability.References (and other information about vulnerability). It would be more logical for me to use References instead of PrimaryURL.