### PR TITLE
Add support for exposing Prometheus metrics endpoint

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/openclarity/kubeclarity/runtime_scan v0.0.0
 	github.com/openclarity/kubeclarity/runtime_scan/api v0.0.0
 	github.com/openclarity/kubeclarity/shared v0.0.0
+	github.com/prometheus/client_golang v1.14.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/viper v1.13.0
@@ -68,7 +69,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.19 // indirect
 	github.com/aws/smithy-go v1.13.3 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220517224237-e6f29200ae04 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21 // indirect
 	github.com/containerd/containerd v1.6.8 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.12.1 // indirect
@@ -137,6 +140,7 @@ require (
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v1.14.12 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mholt/archiver/v3 v3.5.1 // indirect
 	github.com/microsoft/go-rustaudit v0.0.0-20220808201409-204dfee52032 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
@@ -156,6 +160,9 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_model v0.3.0 // indirect
+	github.com/prometheus/common v0.37.0 // indirect
+	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -221,6 +221,7 @@ github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220517224237-
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
@@ -244,6 +245,7 @@ github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
@@ -430,9 +432,11 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
+github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
@@ -884,6 +888,7 @@ github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A
 github.com/mattn/go-sqlite3 v1.14.12 h1:TJ1bhYJPV44phC+IMu1u2K/i5RriLTPe+yc68XDJ1Z0=
 github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Clwo=
@@ -1029,10 +1034,15 @@ github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3O
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
+github.com/prometheus/client_golang v1.14.0 h1:nJdhIvne2eSX/XRAFV9PcvFFRbrjbcTUj0VP62TMhnw=
+github.com/prometheus/client_golang v1.14.0/go.mod h1:8vpkKitgIVNcqrRBWh1C4TIUQgYNtG/XQE4E/Zae36Y=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
+github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
@@ -1041,6 +1051,9 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.30.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
+github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
+github.com/prometheus/common v0.37.0 h1:ccBbHCgIiT9uSoFY0vX8H3zsNR5eLt17/RQLUvn8pXE=
+github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.0-20190522114515-bc1a522cf7b1/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
@@ -1050,6 +1063,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
+github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
@@ -1428,6 +1443,7 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1448,6 +1464,7 @@ golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.1.0 h1:isLCZuhj4v+tYv7eskaN4v/TM+A1begWWgyVJDdl1+Y=
 golang.org/x/oauth2 v0.1.0/go.mod h1:G9FE4dLTsbXUu90h/Pf85g4w1D+SSAgR+q46nJZ8M4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/backend/pkg/backend/backend.go
+++ b/backend/pkg/backend/backend.go
@@ -19,14 +19,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/Portshift/go-utils/healthz"
+	k8sutils "github.com/Portshift/go-utils/k8s"
+	"github.com/openclarity/kubeclarity/backend/pkg/metrics"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
 	"os"
 	"os/signal"
 	"syscall"
-
-	"github.com/Portshift/go-utils/healthz"
-	k8sutils "github.com/Portshift/go-utils/k8s"
-	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/kubernetes"
 
 	_config "github.com/openclarity/kubeclarity/backend/pkg/config"
 	_database "github.com/openclarity/kubeclarity/backend/pkg/database"
@@ -111,6 +111,10 @@ func Run() {
 	}
 	restServer.Start(errChan)
 	defer restServer.Stop()
+
+	if config.PrometheusRefreshIntervalSeconds > 0 {
+		metrics.ProduceMetrics(dbHandler, config.PrometheusRefreshIntervalSeconds).StartRecordingMetrics()
+	}
 
 	healthServer.SetIsReady(true)
 	log.Info("KubeClarity backend is ready")

--- a/backend/pkg/backend/backend.go
+++ b/backend/pkg/backend/backend.go
@@ -19,14 +19,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Portshift/go-utils/healthz"
-	k8sutils "github.com/Portshift/go-utils/k8s"
-	"github.com/openclarity/kubeclarity/backend/pkg/metrics"
-	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/kubernetes"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/openclarity/kubeclarity/backend/pkg/metrics"
+
+	"github.com/Portshift/go-utils/healthz"
+	k8sutils "github.com/Portshift/go-utils/k8s"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
 
 	_config "github.com/openclarity/kubeclarity/backend/pkg/config"
 	_database "github.com/openclarity/kubeclarity/backend/pkg/database"

--- a/backend/pkg/backend/backend.go
+++ b/backend/pkg/backend/backend.go
@@ -75,8 +75,7 @@ func Run() {
 
 	healthServer.SetIsReady(false)
 
-	// globalCtx, globalCancel := context.WithCancel(context.Background())
-	_, globalCancel := context.WithCancel(context.Background())
+	globalCtx, globalCancel := context.WithCancel(context.Background())
 	defer globalCancel()
 
 	log.Info("KubeClarity backend is running")
@@ -113,7 +112,7 @@ func Run() {
 	defer restServer.Stop()
 
 	if config.PrometheusRefreshIntervalSeconds > 0 {
-		metrics.CreateMetrics(dbHandler, config.PrometheusRefreshIntervalSeconds).StartRecordingMetrics(context.Background())
+		metrics.CreateMetrics(dbHandler, config.PrometheusRefreshIntervalSeconds).StartRecordingMetrics(globalCtx)
 	}
 
 	healthServer.SetIsReady(true)

--- a/backend/pkg/backend/backend.go
+++ b/backend/pkg/backend/backend.go
@@ -113,7 +113,7 @@ func Run() {
 	defer restServer.Stop()
 
 	if config.PrometheusRefreshIntervalSeconds > 0 {
-		metrics.ProduceMetrics(dbHandler, config.PrometheusRefreshIntervalSeconds).StartRecordingMetrics()
+		metrics.CreateMetrics(dbHandler, config.PrometheusRefreshIntervalSeconds).StartRecordingMetrics(context.Background())
 	}
 
 	healthServer.SetIsReady(true)

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -27,6 +27,8 @@ const (
 	BackendRestPort    = "BACKEND_REST_PORT"
 	HealthCheckAddress = "HEALTH_CHECK_ADDRESS"
 
+	PrometheusRefreshIntervalSeconds = "PROMETHEUS_REFRESH_INTERVAL_SECONDS"
+
 	DBNameEnvVar              = "DB_NAME"
 	DBUserEnvVar              = "DB_USER"
 	DBPasswordEnvVar          = "DB_PASS"
@@ -43,6 +45,9 @@ const (
 type Config struct {
 	BackendRestPort    int
 	HealthCheckAddress string
+
+	// How often to refresh Prometheus data in seconds
+	PrometheusRefreshIntervalSeconds int
 
 	// database config
 	DatabaseDriver            string
@@ -62,6 +67,8 @@ func LoadConfig() (*Config, error) {
 
 	config.BackendRestPort = viper.GetInt(BackendRestPort)
 	config.HealthCheckAddress = viper.GetString(HealthCheckAddress)
+
+	config.PrometheusRefreshIntervalSeconds = viper.GetInt(PrometheusRefreshIntervalSeconds)
 
 	config.DatabaseDriver = viper.GetString(DatabaseDriver)
 	config.DBPassword = viper.GetString(DBPasswordEnvVar)

--- a/backend/pkg/metrics/README.md
+++ b/backend/pkg/metrics/README.md
@@ -5,7 +5,14 @@ the endpoint by setting the environment variable `PROMETHEUS_REFRESH_INTERVAL_SE
 to value larger than zero. There is no particular need to scrape these metrics very
 often, so once every 300 seconds is fine.
 
-You can set this value in the `values.yaml` file.
+Enable Prometheus by flipping the "enable" flag to "true" in the `values.yaml`:
+
+```
+kubeclarity:
+  prometheus:
+    enabled: false
+    refreshIntervalSeconds: 300 
+```
 
 The metrics that are exposed are:
 

--- a/backend/pkg/metrics/README.md
+++ b/backend/pkg/metrics/README.md
@@ -9,16 +9,17 @@ You can set this value in the `values.yaml` file.
 
 The metrics that are exposed are:
 
-| Metric                                              | Explanation                                        |
-|-----------------------------------------------------|----------------------------------------------------|
-| kubeclarity_application_vulnerability               | Count of vulnerabilities per application and level |
-| kubeclarity_number_of_applications                  | The total number of applications                   |
-| kubeclarity_number_of_fixable_vulnerabilities       | The number of fixable vulnerabilities per severity |
-| kubeclarity_number_of_fixable_vulnerabilities_total | The total number of fixable vulnerabilities        |
-| kubeclarity_number_of_packages                      | The total number of packages                       |
-| kubeclarity_number_of_resources                     | The total number of resources                      |
-| kubeclarity_number_of_vulnerabilities               | The number of vulnerabilities per severity         |
-| kubeclarity_number_of_vulnerabilities_total         | The total number of vulnerabilities                |
+| Metric                                              | Explanation                                                        |
+|-----------------------------------------------------|--------------------------------------------------------------------|
+| kubeclarity_application_vulnerability               | Count of vulnerabilities per application, environment and severity |
+| kubeclarity_number_of_applications                  | The total number of applications                                   |
+| kubeclarity_number_of_fixable_vulnerabilities       | The number of fixable vulnerabilities per severity                 |
+| kubeclarity_number_of_fixable_vulnerabilities_total | The total number of fixable vulnerabilities                        |
+| kubeclarity_number_of_packages                      | The total number of packages                                       |
+| kubeclarity_number_of_resources                     | The total number of resources                                      |
+| kubeclarity_number_of_vulnerabilities               | The number of vulnerabilities per severity                         |
+| kubeclarity_number_of_vulnerabilities_total         | The total number of vulnerabilities                                |
+| kubeclarity_vulnerability_trend                     | Vulnerability trend in a 60 minute time window                     |
 
 ## Prometheus alert
 

--- a/backend/pkg/metrics/README.md
+++ b/backend/pkg/metrics/README.md
@@ -1,0 +1,31 @@
+# Prometheus
+
+In order to expose metrics from KubeClarity to Prometheus, you need to enable
+the endpoint by setting the environment variable `PROMETHEUS_REFRESH_INTERVAL_SECONDS`
+to value larger than zero. There is no particular need to scrape these metrics very
+often, so once every 300 seconds is fine.
+
+You can set this value in the `values.yaml` file.
+
+The metrics that are exposed are:
+
+| Metric                                              | Explanation                                        |
+|-----------------------------------------------------|----------------------------------------------------|
+| kubeclarity_application_vulnerability               | Count of vulnerabilities per application and level |
+| kubeclarity_number_of_applications                  | The total number of applications                   |
+| kubeclarity_number_of_fixable_vulnerabilities       | The number of fixable vulnerabilities per severity |
+| kubeclarity_number_of_fixable_vulnerabilities_total | The total number of fixable vulnerabilities        |
+| kubeclarity_number_of_packages                      | The total number of packages                       |
+| kubeclarity_number_of_resources                     | The total number of resources                      |
+| kubeclarity_number_of_vulnerabilities               | The number of vulnerabilities per severity         |
+| kubeclarity_number_of_vulnerabilities_total         | The total number of vulnerabilities                |
+
+## Prometheus alert
+
+For an example of how to get a Prometheus alert when new issues in the cluster are found, see:
+[alertmanager-kubeclarity.yaml](alertmanager-kubeclarity.yaml)
+
+## Grafana
+
+The file [kubeclarity-dashboard.json](kubeclarity-dashboard.json) contains a dashboard which
+you can add to your Grafana instance.

--- a/backend/pkg/metrics/README.md
+++ b/backend/pkg/metrics/README.md
@@ -16,17 +16,17 @@ kubeclarity:
 
 The metrics that are exposed are:
 
-| Metric                                              | Explanation                                                        |
-|-----------------------------------------------------|--------------------------------------------------------------------|
-| kubeclarity_application_vulnerability               | Count of vulnerabilities per application, environment and severity |
-| kubeclarity_number_of_applications                  | The total number of applications                                   |
-| kubeclarity_number_of_fixable_vulnerabilities       | The number of fixable vulnerabilities per severity                 |
-| kubeclarity_number_of_fixable_vulnerabilities_total | The total number of fixable vulnerabilities                        |
-| kubeclarity_number_of_packages                      | The total number of packages                                       |
-| kubeclarity_number_of_resources                     | The total number of resources                                      |
-| kubeclarity_number_of_vulnerabilities               | The number of vulnerabilities per severity                         |
-| kubeclarity_number_of_vulnerabilities_total         | The total number of vulnerabilities                                |
-| kubeclarity_vulnerability_trend                     | Vulnerability trend in a 60 minute time window                     |
+| Metric                                               | Explanation                                                        |
+|------------------------------------------------------|--------------------------------------------------------------------|
+| kubeclarity_application_vulnerability                | Count of vulnerabilities per application, environment and severity |
+| kubeclarity_number_of_applications                   | The total number of applications                                   |
+| kubeclarity_number_of_fixable_vulnerabilities        | The number of fixable vulnerabilities per severity                 |
+| kubeclarity_number_of_fixable_vulnerabilities_amount | The total number of fixable vulnerabilities                        |
+| kubeclarity_number_of_packages                       | The total number of packages                                       |
+| kubeclarity_number_of_resources                      | The total number of resources                                      |
+| kubeclarity_number_of_vulnerabilities                | The number of vulnerabilities per severity                         |
+| kubeclarity_number_of_vulnerabilities_amount         | The total number of vulnerabilities                                |
+| kubeclarity_vulnerability_trend                      | Vulnerability trend in a 60 minute time window                     |
 
 ## Prometheus alert
 

--- a/backend/pkg/metrics/alertmanager-kubeclarity.yaml
+++ b/backend/pkg/metrics/alertmanager-kubeclarity.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: alertmanager-kubeclarity
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/component: alert-router
+    prometheus: k8s
+    role: alert-rules
+  name: alertmanager-kubeclarity
+  namespace: monitoring
+spec:
+  groups:
+    - name: alerts.kubeclarity
+      rules:
+        - alert: PodWithSecurityIssue
+          annotations:
+            description: '{{ $labels.name }} in {{ $labels.environment}} has a new security issue on level CRITICAL or HIGH.'
+          for: 1m
+          expr: increase(kubeclarity_application_vulnerability{severity=~"CRITICAL|HIGH"}[1h]) > 0
+          labels:
+            severity: critical

--- a/backend/pkg/metrics/kubeclarity-dashboard.json
+++ b/backend/pkg/metrics/kubeclarity-dashboard.json
@@ -486,7 +486,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(kubeclarity_number_of_fixable_vulnerabilities_total)",
+          "expr": "sum(kubeclarity_number_of_fixable_vulnerabilities_amount)",
           "legendFormat": "Fixable vulnerabilities",
           "range": true,
           "refId": "A"
@@ -497,7 +497,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(kubeclarity_number_of_vulnerabilities_total)-sum(kubeclarity_number_of_fixable_vulnerabilities_total)",
+          "expr": "sum(kubeclarity_number_of_vulnerabilities_amount)-sum(kubeclarity_number_of_fixable_vulnerabilities_amount)",
           "hide": false,
           "legendFormat": "Vulnerabilities without fix",
           "range": true,
@@ -666,7 +666,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(kubeclarity_number_of_fixable_vulnerabilities_total)",
+          "expr": "sum(kubeclarity_number_of_fixable_vulnerabilities_amount)",
           "legendFormat": "Fixable vulnerabilities",
           "range": true,
           "refId": "A"
@@ -677,7 +677,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(kubeclarity_number_of_vulnerabilities_total)  ",
+          "expr": "sum(kubeclarity_number_of_vulnerabilities_amount)  ",
           "hide": false,
           "legendFormat": "Vulnerabilities with no known fix",
           "range": true,

--- a/backend/pkg/metrics/kubeclarity-dashboard.json
+++ b/backend/pkg/metrics/kubeclarity-dashboard.json
@@ -1,0 +1,954 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 26,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Vulnerabilities by environment and severity",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "links": [
+            {
+              "targetBlank": false,
+              "title": "Drill down",
+              "url": "d/Dqp5vA24z/kubeclarity?var-severity=${__field.labels.severity}﻿&${environment:queryparam}"
+            }
+          ],
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 0,
+        "y": 1
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum by (severity) (kubeclarity_application_vulnerability{environment=\"$environment\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Application vulnerabilities in $environment",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "links": [
+            {
+              "targetBlank": false,
+              "title": "Drill down on environment",
+              "url": "d/Dqp5vA24z/kubeclarity?var-environment=${__field.labels.environment}&${severity:queryparam}"
+            }
+          ],
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 7,
+        "y": 1
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum by (environment) (kubeclarity_application_vulnerability{severity=\"$severity\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Environments with vulnerabilities at $severity level",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "links": [
+            {
+              "targetBlank": false,
+              "title": "Drill down",
+              "url": "d/Dqp5vA24z/kubeclarity?var-severity=${__field.labels.severity}﻿&${environment:queryparam}"
+            }
+          ],
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 14,
+        "y": 1
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name) (kubeclarity_application_vulnerability{environment=\"$environment\", severity=\"$severity\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Application vulnerabilities of level $severity in $environment",
+      "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Overview of vulnerabilities",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum by (environment) (kubeclarity_application_vulnerability{severity=\"$severity\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Trend at $severity level",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 10
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kubeclarity_number_of_packages)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of packages / libraries",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 12,
+        "y": 10
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(kubeclarity_number_of_fixable_vulnerabilities_total)",
+          "legendFormat": "Fixable vulnerabilities",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(kubeclarity_number_of_vulnerabilities_total)-sum(kubeclarity_number_of_fixable_vulnerabilities_total)",
+          "hide": false,
+          "legendFormat": "Vulnerabilities without fix",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Types of vulnerabilities",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "This is image, directory or file, typically image",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 14
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kubeclarity_number_of_resources)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of resources",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 900
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 18
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "timezone": [
+          "browser"
+        ],
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(kubeclarity_number_of_fixable_vulnerabilities_total)",
+          "legendFormat": "Fixable vulnerabilities",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(kubeclarity_number_of_vulnerabilities_total)  ",
+          "hide": false,
+          "legendFormat": "Vulnerabilities with no known fix",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Fixable  vulnerabilities vs no known fix",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 6,
+        "y": 18
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "timezone": [
+          "browser"
+        ],
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum by (severity) (kubeclarity_number_of_vulnerabilities)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Vulnerabilities by severity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 13,
+        "y": 18
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "timezone": [
+          "browser"
+        ],
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum by (severity) (kubeclarity_number_of_fixable_vulnerabilities)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Fixable vulnerabilities by severity",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "kubeclarity",
+          "value": "kubeclarity"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "definition": "label_values(kubeclarity_application_vulnerability, environment)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "environment",
+        "options": [],
+        "query": {
+          "query": "label_values(kubeclarity_application_vulnerability, environment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "CRITICAL",
+          "value": "CRITICAL"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "definition": "label_values(kubeclarity_application_vulnerability, severity)",
+        "description": "",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "severity",
+        "options": [],
+        "query": {
+          "query": "label_values(kubeclarity_application_vulnerability, severity)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "KubeClarity",
+  "uid": "Dqp5vA24z",
+  "version": 1,
+  "weekStart": ""
+}

--- a/backend/pkg/metrics/prometheus_metrics.go
+++ b/backend/pkg/metrics/prometheus_metrics.go
@@ -1,0 +1,158 @@
+package metrics
+
+import (
+	"fmt"
+	"github.com/go-openapi/strfmt"
+	"github.com/openclarity/kubeclarity/api/server/restapi/operations"
+	"github.com/openclarity/kubeclarity/backend/pkg/database"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// Prefix is to make metrics unique
+	Prefix string = "kubeclarity"
+)
+
+var (
+	applicationCounter = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: Prefix + "_number_of_applications",
+		Help: "The total number of applications",
+	})
+	resourceCounter = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: Prefix + "_number_of_resources",
+		Help: "The total number of resources",
+	})
+	packageCounter = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: Prefix + "_number_of_packages",
+		Help: "The total number of packages",
+	})
+	vulnerabilityCounter = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: Prefix + "_number_of_vulnerabilities_total",
+		Help: "The total number of vulnerabilities",
+	})
+	fixableVulnerabilityCounter = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: Prefix + "_number_of_fixable_vulnerabilities_total",
+		Help: "The total number of fixable vulnerabilities",
+	})
+	fixableVulnerability = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: Prefix + "_number_of_fixable_vulnerabilities",
+		Help: "The number of fixable vulnerabilities per severity",
+	}, []string{"severity"})
+	vulnerability = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: Prefix + "_number_of_vulnerabilities",
+		Help: "The number of vulnerabilities per severity",
+	}, []string{"severity"})
+	trendGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: Prefix + "_vulnerability_trend",
+		Help: "Incoming vulnerabilities within the last hour",
+	}, []string{"severity"})
+	applicationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: Prefix + "_application_vulnerability",
+		Help: "Count of vulnerabilities per application and level",
+	}, []string{"name", "environment", "severity"})
+)
+
+type Server struct {
+	refreshInterval int
+	dbHandler       *database.Handler
+}
+
+func ProduceMetrics(dbHandler *database.Handler, refreshInterval int) *Server {
+	return &Server{
+		refreshInterval: refreshInterval,
+		dbHandler:       dbHandler,
+	}
+}
+
+func init() {
+	logrus.Infof("Adding /metrics endpoint to http server assumed started with healthz")
+	http.Handle("/metrics", promhttp.Handler())
+}
+
+func (s *Server) recordSummaryCounters() {
+	pkgCount, _ := s.dbHandler.PackageTable().Count(nil)
+	packageCounter.Set(float64(pkgCount))
+	appCount, _ := s.dbHandler.ApplicationTable().Count(nil)
+	applicationCounter.Set(float64(appCount))
+	resCount, _ := s.dbHandler.ResourceTable().Count(nil)
+	resourceCounter.Set(float64(resCount))
+}
+
+func (s *Server) recordTrendCounters() {
+	trends, err := s.dbHandler.NewVulnerabilityTable().
+		GetNewVulnerabilitiesTrends(operations.GetDashboardTrendsVulnerabilitiesParams{
+			StartTime: strfmt.DateTime(time.Now().Add(-60 * time.Minute)),
+			EndTime:   strfmt.DateTime(time.Now()),
+		})
+	if err != nil {
+		logrus.Warnf("failed get vulnernability trends: %v", err)
+		return
+	}
+	for _, trend := range trends {
+		for _, vul := range trend.NumOfVuls {
+			trendGauge.WithLabelValues(string(vul.Severity)).Set(float64(vul.Count))
+		}
+	}
+}
+
+// Gauges for fixable vulnerabilities
+func (s *Server) recordFixableVulnerability() {
+	fixableVulnerabilityCount, _ := s.dbHandler.VulnerabilityTable().CountVulnerabilitiesWithFix()
+	var total uint32 = 0
+	var totalWithFix uint32 = 0
+	for _, fix := range fixableVulnerabilityCount {
+		total += fix.CountTotal
+		totalWithFix += fix.CountWithFix
+		fixableVulnerability.WithLabelValues(fmt.Sprintf("%s", fix.Severity)).Set(float64(fix.CountWithFix))
+		vulnerability.WithLabelValues(fmt.Sprintf("%s", fix.Severity)).Set(float64(fix.CountTotal))
+	}
+	fixableVulnerabilityCounter.Set(float64(totalWithFix))
+	vulnerabilityCounter.Set(float64(total))
+}
+
+func (s *Server) recordApplicationVulnerabilities() {
+	sortDir := string("ASC")
+
+	var applications, _, err = s.dbHandler.ApplicationTable().GetApplicationsAndTotal(
+		database.GetApplicationsParams{
+			GetApplicationsParams: operations.GetApplicationsParams{
+				SortDir: &sortDir,
+				SortKey: "applicationName",
+			},
+		})
+	if err != nil {
+		logrus.Warnf("failed get applications: %v", err)
+		return
+	}
+
+	for _, application := range applications {
+		for _, env := range strings.Split(application.Environments, "|") {
+			if env != "" {
+				applicationGauge.WithLabelValues(application.Name, env, "NEGLIGIBLE").Set(float64(application.TotalNegCount))
+				applicationGauge.WithLabelValues(application.Name, env, "LOW").Set(float64(application.TotalLowCount))
+				applicationGauge.WithLabelValues(application.Name, env, "MEDIUM").Set(float64(application.TotalMediumCount))
+				applicationGauge.WithLabelValues(application.Name, env, "HIGH").Set(float64(application.TotalHighCount))
+				applicationGauge.WithLabelValues(application.Name, env, "CRITICAL").Set(float64(application.TotalCriticalCount))
+			}
+		}
+	}
+}
+
+func (s *Server) StartRecordingMetrics() {
+	go func() {
+		for {
+			s.recordFixableVulnerability()
+			s.recordSummaryCounters()
+			s.recordApplicationVulnerabilities()
+			s.recordTrendCounters()
+
+			time.Sleep(time.Duration(s.refreshInterval) * time.Second)
+		}
+	}()
+}

--- a/backend/pkg/metrics/prometheus_metrics.go
+++ b/backend/pkg/metrics/prometheus_metrics.go
@@ -17,20 +17,23 @@ package metrics
 
 import (
 	"context"
-	"github.com/go-openapi/strfmt"
-	"github.com/openclarity/kubeclarity/api/server/restapi/operations"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/openclarity/kubeclarity/backend/pkg/database"
+
+	"github.com/go-openapi/strfmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
-	"net/http"
-	"strings"
-	"time"
+
+	"github.com/openclarity/kubeclarity/api/server/restapi/operations"
 )
 
 const (
-	// Prefix is to make metrics unique
+	// Prefix is to make metrics unique.
 	Prefix string = "kubeclarity"
 )
 
@@ -48,11 +51,11 @@ var (
 		Help: "The total number of packages",
 	})
 	vulnerabilityCounter = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: Prefix + "_number_of_vulnerabilities_total",
+		Name: Prefix + "_number_of_vulnerabilities_amount",
 		Help: "The total number of vulnerabilities",
 	})
 	fixableVulnerabilityCounter = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: Prefix + "_number_of_fixable_vulnerabilities_total",
+		Name: Prefix + "_number_of_fixable_vulnerabilities_amount",
 		Help: "The total number of fixable vulnerabilities",
 	})
 	fixableVulnerability = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -122,7 +125,7 @@ func (s *Server) recordTrendCounters() {
 	}
 }
 
-// Gauges for fixable vulnerabilities
+// Gauges for fixable vulnerabilities.
 func (s *Server) recordFixableVulnerability() {
 	fixableVulnerabilityCount, err := s.dbHandler.VulnerabilityTable().CountVulnerabilitiesWithFix()
 	if err != nil {
@@ -130,8 +133,8 @@ func (s *Server) recordFixableVulnerability() {
 		return
 	}
 
-	var total uint32 = 0
-	var totalWithFix uint32 = 0
+	var total uint32
+	var totalWithFix uint32
 	for _, fix := range fixableVulnerabilityCount {
 		total += fix.CountTotal
 		totalWithFix += fix.CountWithFix
@@ -145,7 +148,7 @@ func (s *Server) recordFixableVulnerability() {
 func (s *Server) recordApplicationVulnerabilities() {
 	sortDir := string("ASC")
 
-	var applications, _, err = s.dbHandler.ApplicationTable().GetApplicationsAndTotal(
+	applications, _, err := s.dbHandler.ApplicationTable().GetApplicationsAndTotal(
 		database.GetApplicationsParams{
 			GetApplicationsParams: operations.GetApplicationsParams{
 				SortDir: &sortDir,

--- a/backend/pkg/metrics/prometheus_metrics.go
+++ b/backend/pkg/metrics/prometheus_metrics.go
@@ -174,16 +174,18 @@ func (s *Server) recordApplicationVulnerabilities() {
 }
 
 func (s *Server) StartRecordingMetrics(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			logrus.Info("received stop event")
-			return
-		case <-time.After(time.Duration(s.refreshInterval) * time.Second):
-			s.recordFixableVulnerability()
-			s.recordSummaryCounters()
-			s.recordApplicationVulnerabilities()
-			s.recordTrendCounters()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				logrus.Info("received stop event")
+				return
+			case <-time.After(time.Duration(s.refreshInterval) * time.Second):
+				s.recordFixableVulnerability()
+				s.recordSummaryCounters()
+				s.recordApplicationVulnerabilities()
+				s.recordTrendCounters()
+			}
 		}
-	}
+	}()
 }

--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -100,6 +100,8 @@ spec:
           env:
             - name: ENABLE_DB_INFO_LOGS
               value: "{{ .Values.kubeclarity.enableDBInfoLog }}"
+            - name: PROMETHEUS_REFRESH_INTERVAL_SECONDS
+              value: "{{ .Values.kubeclarity.prometheusRefreshIntervalSeconds }}"
             # DB envs
             {{- if .Values.kubeclarity.dbViewRefreshInterval }}
             - name: DB_VIEW_REFRESH_INTERVAL
@@ -127,6 +129,16 @@ spec:
               value: "{{ .Release.Namespace }}"
             - name: READ_CLUSTER_SECRETS
               value: "{{ index .Values "kubeclarity" "clusterRole" "readClusterSecrets" }}"
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+            - containerPort: 8888
+              name: scan-results
+              protocol: TCP
+            - containerPort: 8081
+              name: health
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /healthz/ready

--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
           env:
             - name: ENABLE_DB_INFO_LOGS
               value: "{{ .Values.kubeclarity.enableDBInfoLog }}"
-{{- if index .Values "prometheus" "enabled" }}
+{{- if index .Values.kubeclarity.prometheus.enabled }}
             - name: PROMETHEUS_REFRESH_INTERVAL_SECONDS
               value: "{{ .Values.kubeclarity.prometheus.refreshIntervalSeconds }}"
 {{- end }}

--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -100,8 +100,10 @@ spec:
           env:
             - name: ENABLE_DB_INFO_LOGS
               value: "{{ .Values.kubeclarity.enableDBInfoLog }}"
+{{- if index .Values "prometheus" "enabled" }}
             - name: PROMETHEUS_REFRESH_INTERVAL_SECONDS
-              value: "{{ .Values.kubeclarity.prometheusRefreshIntervalSeconds }}"
+              value: "{{ .Values.kubeclarity.prometheus.refreshIntervalSeconds }}"
+{{- end }}
             # DB envs
             {{- if .Values.kubeclarity.dbViewRefreshInterval }}
             - name: DB_VIEW_REFRESH_INTERVAL

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -51,7 +51,7 @@ kubeclarity:
     enabled: false
     refreshIntervalSeconds: 300
 
-  podAnnotations: { }
+  podAnnotations: {}
 
   service:
     type: ClusterIP

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -47,13 +47,16 @@ kubeclarity:
 
   enableDBInfoLog: false
 
-  podAnnotations: {}
+  # A value greater than 0 will enable the Prometheus metrics endpoint:
+  prometheusRefreshIntervalSeconds: 0
+
+  podAnnotations: { }
 
   service:
     type: ClusterIP
 
   ## In case of postgres refresh interval of refreshing materialized views in seconds
-# dbViewRefreshInterval: 5
+  # dbViewRefreshInterval: 5
 
   resources:
     requests:

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -47,8 +47,9 @@ kubeclarity:
 
   enableDBInfoLog: false
 
-  # A value greater than 0 will enable the Prometheus metrics endpoint:
-  prometheusRefreshIntervalSeconds: 0
+  prometheus:
+    enabled: false
+    refreshIntervalSeconds: 300
 
   podAnnotations: { }
 


### PR DESCRIPTION
This PR will add a /metrics endpoint to KubeClarity. It needs to be enabled with a config value, with a default of not being enabled. 

In order to expose metrics from KubeClarity to Prometheus, you need to enable
the endpoint by setting the environment variable `PROMETHEUS_REFRESH_INTERVAL_SECONDS`
to value larger than zero, for instance 300 which means that the Prometheus endpoint will get updated values every 5 minutes.

KubeClarity uses healthz for readiness / liveness, and as the metrics is added with `http.Handle("/metrics", promhttp.Handler())`, this will make it live on port 8081.

I have added an Alertmanager example, and a Grafana dashboard.

![Grafana Dashboard](https://user-images.githubusercontent.com/437756/211850094-2ef56919-73b7-4510-8d59-913af38f5dac.png)

This PR will close #63 