### PR TITLE
update curl image tag to 7.87.0 (latest)

### DIFF
--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -28,7 +28,7 @@ curl:
   image:
     registry: "docker.io"
     repository: curlimages/curl
-    tag: 7.84.0
+    tag: 7.87.0
 ## End of Curl Values
 #######################################################################################
 


### PR DESCRIPTION
Update curl image to a non vulnerable image
```
$ grype --add-cpes-if-none --only-fixed docker.io/curlimages/curl:7.84.0
 ✔ Vulnerability DB        [no update available]
New version of grype is available: 0.55.0 (currently running: 0.52.0)
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [21 packages]
 ✔ Scanned image           [4 vulnerabilities]

NAME          INSTALLED  FIXED-IN   TYPE  VULNERABILITY   SEVERITY
libcrypto1.1  1.1.1p-r0  1.1.1q-r0  apk   CVE-2022-2097   Medium
libssl1.1     1.1.1p-r0  1.1.1q-r0  apk   CVE-2022-2097   Medium
zlib          1.2.12-r1  1.2.12-r2  apk   CVE-2022-37434  Critical
```

```
$ grype --add-cpes-if-none --only-fixed docker.io/curlimages/curl:7.87.0
 ✔ Vulnerability DB        [no update available]
New version of grype is available: 0.55.0 (currently running: 0.52.0)
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [21 packages]
 ✔ Scanned image           [0 vulnerabilities]

No vulnerabilities found
```