### PR TITLE
Prometheus metrics improvements

### DIFF
--- a/backend/pkg/metrics/README.md
+++ b/backend/pkg/metrics/README.md
@@ -16,17 +16,17 @@ kubeclarity:
 
 The metrics that are exposed are:
 
-| Metric                                               | Explanation                                                        |
-|------------------------------------------------------|--------------------------------------------------------------------|
-| kubeclarity_application_vulnerability                | Count of vulnerabilities per application, environment and severity |
-| kubeclarity_number_of_applications                   | The total number of applications                                   |
-| kubeclarity_number_of_fixable_vulnerabilities        | The number of fixable vulnerabilities per severity                 |
-| kubeclarity_number_of_fixable_vulnerabilities_amount | The total number of fixable vulnerabilities                        |
-| kubeclarity_number_of_packages                       | The total number of packages                                       |
-| kubeclarity_number_of_resources                      | The total number of resources                                      |
-| kubeclarity_number_of_vulnerabilities                | The number of vulnerabilities per severity                         |
-| kubeclarity_number_of_vulnerabilities_amount         | The total number of vulnerabilities                                |
-| kubeclarity_vulnerability_trend                      | Vulnerability trend in a 60 minute time window                     |
+| Metric                                               | Explanation                                                                          |
+|------------------------------------------------------|--------------------------------------------------------------------------------------|
+| kubeclarity_application_vulnerability                | Count of vulnerabilities per application, environment and importance (i.e. severity) |
+| kubeclarity_number_of_applications                   | The total number of applications                                                     |
+| kubeclarity_number_of_fixable_vulnerabilities        | The number of fixable vulnerabilities per importance (i.e. severity)                 |
+| kubeclarity_number_of_fixable_vulnerabilities_amount | The total number of fixable vulnerabilities                                          |
+| kubeclarity_number_of_packages                       | The total number of packages                                                         |
+| kubeclarity_number_of_resources                      | The total number of resources                                                        |
+| kubeclarity_number_of_vulnerabilities                | The number of vulnerabilities per importance (i.e. severity)                         |
+| kubeclarity_number_of_vulnerabilities_amount         | The total number of vulnerabilities                                                  |
+| kubeclarity_vulnerability_trend                      | Vulnerability trend in a 60 minute time window by importance (i.e. severity)         |
 
 ## Prometheus alert
 

--- a/backend/pkg/metrics/README.md
+++ b/backend/pkg/metrics/README.md
@@ -16,17 +16,17 @@ kubeclarity:
 
 The metrics that are exposed are:
 
-| Metric                                               | Explanation                                                                          |
-|------------------------------------------------------|--------------------------------------------------------------------------------------|
-| kubeclarity_application_vulnerability                | Count of vulnerabilities per application, environment and importance (i.e. severity) |
-| kubeclarity_number_of_applications                   | The total number of applications                                                     |
-| kubeclarity_number_of_fixable_vulnerabilities        | The number of fixable vulnerabilities per importance (i.e. severity)                 |
-| kubeclarity_number_of_fixable_vulnerabilities_amount | The total number of fixable vulnerabilities                                          |
-| kubeclarity_number_of_packages                       | The total number of packages                                                         |
-| kubeclarity_number_of_resources                      | The total number of resources                                                        |
-| kubeclarity_number_of_vulnerabilities                | The number of vulnerabilities per importance (i.e. severity)                         |
-| kubeclarity_number_of_vulnerabilities_amount         | The total number of vulnerabilities                                                  |
-| kubeclarity_vulnerability_trend                      | Vulnerability trend in a 60 minute time window by importance (i.e. severity)         |
+| Metric                                               | Explanation                                                        |
+|------------------------------------------------------|--------------------------------------------------------------------|
+| kubeclarity_application_vulnerability                | Count of vulnerabilities per application, environment and severity |
+| kubeclarity_number_of_applications                   | The total number of applications                                   |
+| kubeclarity_number_of_fixable_vulnerabilities        | The number of fixable vulnerabilities per severity                 |
+| kubeclarity_number_of_fixable_vulnerabilities_amount | The total number of fixable vulnerabilities                        |
+| kubeclarity_number_of_packages                       | The total number of packages                                       |
+| kubeclarity_number_of_resources                      | The total number of resources                                      |
+| kubeclarity_number_of_vulnerabilities                | The number of vulnerabilities per severity                         |
+| kubeclarity_number_of_vulnerabilities_amount         | The total number of vulnerabilities                                |
+| kubeclarity_vulnerability_trend                      | Vulnerability trend in a 60 minute time window                     |
 
 ## Prometheus alert
 

--- a/backend/pkg/metrics/alertmanager-kubeclarity.yaml
+++ b/backend/pkg/metrics/alertmanager-kubeclarity.yaml
@@ -17,6 +17,6 @@ spec:
           annotations:
             description: '{{ $labels.name }} in {{ $labels.environment}} has a new security issue on level CRITICAL or HIGH.'
           for: 1m
-          expr: increase(kubeclarity_application_vulnerability{severity=~"CRITICAL|HIGH"}[1h]) > 0
+          expr: increase(kubeclarity_application_vulnerability{importance=~"CRITICAL|HIGH"}[1h]) > 0
           labels:
             severity: critical

--- a/backend/pkg/metrics/alertmanager-kubeclarity.yaml
+++ b/backend/pkg/metrics/alertmanager-kubeclarity.yaml
@@ -17,6 +17,6 @@ spec:
           annotations:
             description: '{{ $labels.name }} in {{ $labels.environment}} has a new security issue on level CRITICAL or HIGH.'
           for: 1m
-          expr: increase(kubeclarity_application_vulnerability{importance=~"CRITICAL|HIGH"}[1h]) > 0
+          expr: increase(kubeclarity_application_vulnerability{vul_severity=~"CRITICAL|HIGH"}[1h]) > 0
           labels:
             severity: critical

--- a/backend/pkg/metrics/kubeclarity-dashboard.json
+++ b/backend/pkg/metrics/kubeclarity-dashboard.json
@@ -38,7 +38,7 @@
       },
       "id": 12,
       "panels": [],
-      "title": "Vulnerabilities by environment and severity",
+      "title": "Vulnerabilities by environment and importance",
       "type": "row"
     },
     {
@@ -63,7 +63,7 @@
             {
               "targetBlank": false,
               "title": "Drill down",
-              "url": "d/Dqp5vA24z/kubeclarity?var-severity=${__field.labels.severity}﻿&${environment:queryparam}"
+              "url": "d/Dqp5vA24z/kubeclarity?var-importance=${__field.labels.importance}﻿&${environment:queryparam}"
             }
           ],
           "mappings": []
@@ -103,7 +103,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (severity) (kubeclarity_application_vulnerability{environment=\"$environment\"})",
+          "expr": "sum by (importance) (kubeclarity_application_vulnerability{environment=\"$environment\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -134,7 +134,7 @@
             {
               "targetBlank": false,
               "title": "Drill down on environment",
-              "url": "d/Dqp5vA24z/kubeclarity?var-environment=${__field.labels.environment}&${severity:queryparam}"
+              "url": "d/Dqp5vA24z/kubeclarity?var-environment=${__field.labels.environment}&${importance:queryparam}"
             }
           ],
           "mappings": []
@@ -175,13 +175,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (environment) (kubeclarity_application_vulnerability{severity=\"$severity\"})",
+          "expr": "sum by (environment) (kubeclarity_application_vulnerability{importance=\"$importance\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Environments with vulnerabilities at $severity level",
+      "title": "Environments with vulnerabilities at $importance level",
       "type": "piechart"
     },
     {
@@ -206,7 +206,7 @@
             {
               "targetBlank": false,
               "title": "Drill down",
-              "url": "d/Dqp5vA24z/kubeclarity?var-severity=${__field.labels.severity}﻿&${environment:queryparam}"
+              "url": "d/Dqp5vA24z/kubeclarity?var-importance=${__field.labels.importance}﻿&${environment:queryparam}"
             }
           ],
           "mappings": []
@@ -246,13 +246,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (name) (kubeclarity_application_vulnerability{environment=\"$environment\", severity=\"$severity\"})",
+          "expr": "sum by (name) (kubeclarity_application_vulnerability{environment=\"$environment\", importance=\"$importance\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Application vulnerabilities of level $severity in $environment",
+      "title": "Application vulnerabilities of level $importance in $environment",
       "type": "piechart"
     },
     {
@@ -353,13 +353,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (environment) (kubeclarity_application_vulnerability{severity=\"$severity\"})",
+          "expr": "sum by (environment) (kubeclarity_application_vulnerability{importance=\"$importance\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Trend at $severity level",
+      "title": "Trend at $importance level",
       "type": "timeseries"
     },
     {
@@ -774,13 +774,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (severity) (kubeclarity_number_of_vulnerabilities)",
+          "expr": "sum by (importance) (kubeclarity_number_of_vulnerabilities)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Vulnerabilities by severity",
+      "title": "Vulnerabilities by importance",
       "type": "timeseries"
     },
     {
@@ -870,13 +870,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (severity) (kubeclarity_number_of_fixable_vulnerabilities)",
+          "expr": "sum by (importance) (kubeclarity_number_of_fixable_vulnerabilities)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Fixable vulnerabilities by severity",
+      "title": "Fixable vulnerabilities by importance",
       "type": "timeseries"
     }
   ],
@@ -922,15 +922,15 @@
           "type": "prometheus",
           "uid": "P1809F7CD0C75ACF3"
         },
-        "definition": "label_values(kubeclarity_application_vulnerability, severity)",
+        "definition": "label_values(kubeclarity_application_vulnerability, importance)",
         "description": "",
         "hide": 0,
         "includeAll": false,
         "multi": false,
-        "name": "severity",
+        "name": "importance",
         "options": [],
         "query": {
-          "query": "label_values(kubeclarity_application_vulnerability, severity)",
+          "query": "label_values(kubeclarity_application_vulnerability, importance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/backend/pkg/metrics/kubeclarity-dashboard.json
+++ b/backend/pkg/metrics/kubeclarity-dashboard.json
@@ -38,7 +38,7 @@
       },
       "id": 12,
       "panels": [],
-      "title": "Vulnerabilities by environment and importance",
+      "title": "Vulnerabilities by environment and vul_severity",
       "type": "row"
     },
     {
@@ -63,7 +63,7 @@
             {
               "targetBlank": false,
               "title": "Drill down",
-              "url": "d/Dqp5vA24z/kubeclarity?var-importance=${__field.labels.importance}﻿&${environment:queryparam}"
+              "url": "d/Dqp5vA24z/kubeclarity?var-vul_severity=${__field.labels.vul_severity}﻿&${environment:queryparam}"
             }
           ],
           "mappings": []
@@ -103,7 +103,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (importance) (kubeclarity_application_vulnerability{environment=\"$environment\"})",
+          "expr": "sum by (vul_severity) (kubeclarity_application_vulnerability{environment=\"$environment\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -134,7 +134,7 @@
             {
               "targetBlank": false,
               "title": "Drill down on environment",
-              "url": "d/Dqp5vA24z/kubeclarity?var-environment=${__field.labels.environment}&${importance:queryparam}"
+              "url": "d/Dqp5vA24z/kubeclarity?var-environment=${__field.labels.environment}&${vul_severity:queryparam}"
             }
           ],
           "mappings": []
@@ -175,13 +175,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (environment) (kubeclarity_application_vulnerability{importance=\"$importance\"})",
+          "expr": "sum by (environment) (kubeclarity_application_vulnerability{vul_severity=\"$vul_severity\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Environments with vulnerabilities at $importance level",
+      "title": "Environments with vulnerabilities at $vul_severity level",
       "type": "piechart"
     },
     {
@@ -206,7 +206,7 @@
             {
               "targetBlank": false,
               "title": "Drill down",
-              "url": "d/Dqp5vA24z/kubeclarity?var-importance=${__field.labels.importance}﻿&${environment:queryparam}"
+              "url": "d/Dqp5vA24z/kubeclarity?var-vul_severity=${__field.labels.vul_severity}﻿&${environment:queryparam}"
             }
           ],
           "mappings": []
@@ -246,13 +246,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (name) (kubeclarity_application_vulnerability{environment=\"$environment\", importance=\"$importance\"})",
+          "expr": "sum by (name) (kubeclarity_application_vulnerability{environment=\"$environment\", vul_severity=\"$vul_severity\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Application vulnerabilities of level $importance in $environment",
+      "title": "Application vulnerabilities of level $vul_severity in $environment",
       "type": "piechart"
     },
     {
@@ -353,13 +353,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (environment) (kubeclarity_application_vulnerability{importance=\"$importance\"})",
+          "expr": "sum by (environment) (kubeclarity_application_vulnerability{vul_severity=\"$vul_severity\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Trend at $importance level",
+      "title": "Trend at $vul_severity level",
       "type": "timeseries"
     },
     {
@@ -774,13 +774,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (importance) (kubeclarity_number_of_vulnerabilities)",
+          "expr": "sum by (vul_severity) (kubeclarity_number_of_vulnerabilities)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Vulnerabilities by importance",
+      "title": "Vulnerabilities by vul_severity",
       "type": "timeseries"
     },
     {
@@ -870,13 +870,13 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (importance) (kubeclarity_number_of_fixable_vulnerabilities)",
+          "expr": "sum by (vul_severity) (kubeclarity_number_of_fixable_vulnerabilities)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Fixable vulnerabilities by importance",
+      "title": "Fixable vulnerabilities by vul_severity",
       "type": "timeseries"
     }
   ],
@@ -922,15 +922,15 @@
           "type": "prometheus",
           "uid": "P1809F7CD0C75ACF3"
         },
-        "definition": "label_values(kubeclarity_application_vulnerability, importance)",
+        "definition": "label_values(kubeclarity_application_vulnerability, vul_severity)",
         "description": "",
         "hide": 0,
         "includeAll": false,
         "multi": false,
-        "name": "importance",
+        "name": "vul_severity",
         "options": [],
         "query": {
-          "query": "label_values(kubeclarity_application_vulnerability, importance)",
+          "query": "label_values(kubeclarity_application_vulnerability, vul_severity)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/backend/pkg/metrics/prometheus_metrics.go
+++ b/backend/pkg/metrics/prometheus_metrics.go
@@ -60,20 +60,20 @@ var (
 	})
 	fixableVulnerability = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: Prefix + "_number_of_fixable_vulnerabilities",
-		Help: "The number of fixable vulnerabilities per importance (i.e. severity)",
-	}, []string{"importance"})
+		Help: "The number of fixable vulnerabilities per severity",
+	}, []string{"vul_severity"})
 	vulnerability = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: Prefix + "_number_of_vulnerabilities",
-		Help: "The number of vulnerabilities per importance (i.e. severity)",
-	}, []string{"importance"})
+		Help: "The number of vulnerabilities per severity",
+	}, []string{"vul_severity"})
 	trendGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: Prefix + "_vulnerability_trend",
-		Help: "Vulnerability trend in a 60 minute time window by importance (i.e. severity)",
-	}, []string{"importance"})
+		Help: "Vulnerability trend in a 60 minute time window",
+	}, []string{"vul_severity"})
 	applicationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: Prefix + "_application_vulnerability",
-		Help: "Count of vulnerabilities per application, environment and importance (i.e. severity)",
-	}, []string{"name", "environment", "importance"})
+		Help: "Count of vulnerabilities per application, environment and severity",
+	}, []string{"name", "environment", "vul_severity"})
 )
 
 type Server struct {

--- a/backend/pkg/metrics/prometheus_metrics.go
+++ b/backend/pkg/metrics/prometheus_metrics.go
@@ -60,20 +60,20 @@ var (
 	})
 	fixableVulnerability = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: Prefix + "_number_of_fixable_vulnerabilities",
-		Help: "The number of fixable vulnerabilities per severity",
-	}, []string{"severity"})
+		Help: "The number of fixable vulnerabilities per importance (i.e. severity)",
+	}, []string{"importance"})
 	vulnerability = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: Prefix + "_number_of_vulnerabilities",
-		Help: "The number of vulnerabilities per severity",
-	}, []string{"severity"})
+		Help: "The number of vulnerabilities per importance (i.e. severity)",
+	}, []string{"importance"})
 	trendGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: Prefix + "_vulnerability_trend",
-		Help: "Vulnerability trend in a 60 minute time window",
-	}, []string{"severity"})
+		Help: "Vulnerability trend in a 60 minute time window by importance (i.e. severity)",
+	}, []string{"importance"})
 	applicationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: Prefix + "_application_vulnerability",
-		Help: "Count of vulnerabilities per application, environment and severity",
-	}, []string{"name", "environment", "severity"})
+		Help: "Count of vulnerabilities per application, environment and importance (i.e. severity)",
+	}, []string{"name", "environment", "importance"})
 )
 
 type Server struct {
@@ -174,6 +174,7 @@ func (s *Server) recordApplicationVulnerabilities() {
 }
 
 func (s *Server) StartRecordingMetrics(ctx context.Context) {
+	s.recordVulnerabilities()
 	go func() {
 		for {
 			select {
@@ -181,11 +182,15 @@ func (s *Server) StartRecordingMetrics(ctx context.Context) {
 				logrus.Info("received stop event")
 				return
 			case <-time.After(time.Duration(s.refreshInterval) * time.Second):
-				s.recordFixableVulnerability()
-				s.recordSummaryCounters()
-				s.recordApplicationVulnerabilities()
-				s.recordTrendCounters()
+				s.recordVulnerabilities()
 			}
 		}
 	}()
+}
+
+func (s *Server) recordVulnerabilities() {
+	s.recordFixableVulnerability()
+	s.recordSummaryCounters()
+	s.recordApplicationVulnerabilities()
+	s.recordTrendCounters()
 }


### PR DESCRIPTION
2 things changed with this PR:

1: It turns out that I cannot use label "severity" as it clashes with the following, making alerts complain:
https://github.com/prometheus-operator/kube-prometheus/blob/0ac0d7f9bf5ab1de3e596ff3bdd4b36c52e27267/jsonnet/kube-prometheus/components/alertmanager.libsonnet#L52
This makes alert complain: `"vector contains metrics with the same labelset after applying alert labels"`

Renaming the label `severity` to `vul_severity` to avoid this.

2: Added an initial call to `s.recordVulnerabilities` in order to prime the metrics at startup. Otherwise, metrics will make a dip to zero upon server restart.
