### PR TITLE
Bump grype-server to pick up CPE matching fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ so can be run in kubernetes or via docker standalone.
 
 To start the server:
 ```
-docker run -p 9991:9991 --rm gcr.io/eticloud/k8sec/grype-server:v0.1.4
+docker run -p 9991:9991 --rm gcr.io/eticloud/k8sec/grype-server:v0.1.5
 ```
 
 To run a scan using the server:

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -232,7 +232,7 @@ kubeclarity-grype-server:
   ## Docker Image values.
   docker:
     imageRepo: "gcr.io/eticloud/k8sec"
-    imageTag: "v0.1.4"
+    imageTag: "v0.1.5"
     imagePullPolicy: Always
 
   ## Logging level (debug, info, warning, error, fatal, panic).

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/Microsoft/hcsshim v0.9.4 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
-	github.com/Portshift/grype-server/api v0.0.0-20220929130238-c45f530cdcbb // indirect
+	github.com/Portshift/grype-server/api v0.0.0-20230208095608-6def2f3ebd73 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20220824120805-4b6e5c587895 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -200,8 +200,8 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/Portshift/dockle v0.0.0-20220921124643-b6fc0890ad9d h1:HhRdCokS+6+Ni7E43I6rRIxgcc35QhLfinAMoiXf/Cs=
 github.com/Portshift/dockle v0.0.0-20220921124643-b6fc0890ad9d/go.mod h1:Ppy7ngiLLqCmGGHIku/eswSi5MCWb/bV/eqUKt+wYhw=
-github.com/Portshift/grype-server/api v0.0.0-20220929130238-c45f530cdcbb h1:sXaCuOvQCr1e85WKLBXRsxc1k7ONQGtyy53L9ZqlDyY=
-github.com/Portshift/grype-server/api v0.0.0-20220929130238-c45f530cdcbb/go.mod h1:Ig0CnKAqk4+Yy1XdqA27EJe/Hc5po24M1jXm4Ys4HcQ=
+github.com/Portshift/grype-server/api v0.0.0-20230208095608-6def2f3ebd73 h1:8sqCpq3KlypFkluW9E2DnOdfHdXTI2DSHIuz0+Gney0=
+github.com/Portshift/grype-server/api v0.0.0-20230208095608-6def2f3ebd73/go.mod h1:Ig0CnKAqk4+Yy1XdqA27EJe/Hc5po24M1jXm4Ys4HcQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-crypto v0.0.0-20210920160938-87db9fbc61c7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-crypto v0.0.0-20211112122917-428f8eabeeb3/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=

--- a/runtime_k8s_scanner/go.mod
+++ b/runtime_k8s_scanner/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/Microsoft/hcsshim v0.9.4 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
-	github.com/Portshift/grype-server/api v0.0.0-20220929130238-c45f530cdcbb // indirect
+	github.com/Portshift/grype-server/api v0.0.0-20230208095608-6def2f3ebd73 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20220824120805-4b6e5c587895 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect

--- a/runtime_k8s_scanner/go.sum
+++ b/runtime_k8s_scanner/go.sum
@@ -197,8 +197,8 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/Portshift/go-utils v0.0.0-20211213074910-dd69e9ff3e27 h1:oPNvIsi1lxLgm4TzPwy3ZL70Sle7Ap+unMwq38t+ExY=
 github.com/Portshift/go-utils v0.0.0-20211213074910-dd69e9ff3e27/go.mod h1:8Rx5P+ypVyL+WEC1SNen81kyEjzYq/WD+zWicKKwl7Y=
-github.com/Portshift/grype-server/api v0.0.0-20220929130238-c45f530cdcbb h1:sXaCuOvQCr1e85WKLBXRsxc1k7ONQGtyy53L9ZqlDyY=
-github.com/Portshift/grype-server/api v0.0.0-20220929130238-c45f530cdcbb/go.mod h1:Ig0CnKAqk4+Yy1XdqA27EJe/Hc5po24M1jXm4Ys4HcQ=
+github.com/Portshift/grype-server/api v0.0.0-20230208095608-6def2f3ebd73 h1:8sqCpq3KlypFkluW9E2DnOdfHdXTI2DSHIuz0+Gney0=
+github.com/Portshift/grype-server/api v0.0.0-20230208095608-6def2f3ebd73/go.mod h1:Ig0CnKAqk4+Yy1XdqA27EJe/Hc5po24M1jXm4Ys4HcQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-crypto v0.0.0-20210920160938-87db9fbc61c7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-crypto v0.0.0-20211112122917-428f8eabeeb3/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=

--- a/shared/go.mod
+++ b/shared/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/CycloneDX/cyclonedx-go v0.6.0
 	github.com/CycloneDX/cyclonedx-gomod v1.2.0
-	github.com/Portshift/grype-server/api v0.0.0-20220929130238-c45f530cdcbb
+	github.com/Portshift/grype-server/api v0.0.0-20230208095608-6def2f3ebd73
 	github.com/anchore/grype v0.50.1
 	github.com/anchore/stereoscope v0.0.0-20221006201143-d24c9d626b33
 	github.com/anchore/syft v0.60.3

--- a/shared/go.sum
+++ b/shared/go.sum
@@ -195,8 +195,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
-github.com/Portshift/grype-server/api v0.0.0-20220929130238-c45f530cdcbb h1:sXaCuOvQCr1e85WKLBXRsxc1k7ONQGtyy53L9ZqlDyY=
-github.com/Portshift/grype-server/api v0.0.0-20220929130238-c45f530cdcbb/go.mod h1:Ig0CnKAqk4+Yy1XdqA27EJe/Hc5po24M1jXm4Ys4HcQ=
+github.com/Portshift/grype-server/api v0.0.0-20230208095608-6def2f3ebd73 h1:8sqCpq3KlypFkluW9E2DnOdfHdXTI2DSHIuz0+Gney0=
+github.com/Portshift/grype-server/api v0.0.0-20230208095608-6def2f3ebd73/go.mod h1:Ig0CnKAqk4+Yy1XdqA27EJe/Hc5po24M1jXm4Ys4HcQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-crypto v0.0.0-20210920160938-87db9fbc61c7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-crypto v0.0.0-20211112122917-428f8eabeeb3/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=


### PR DESCRIPTION
Picks up grype-server version v0.1.5 that contains CPE matching configuration fix for the remote grype scanner.