### PR TITLE
Update documentation to align with cisco-open templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description
+
+Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
+related issues, other PRs, or technical references.
+
+Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
+change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.
+
+## Type of Change
+
+- [ ] Bug Fix
+- [ ] New Feature
+- [ ] Breaking Change
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Other (please describe)
+
+## Checklist
+
+- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
+- [ ] Existing issues have been referenced (where applicable)
+- [ ] I have verified this change is not present in other open pull requests
+- [ ] Functionality is documented
+- [ ] All code style checks pass
+- [ ] New code contribution is covered by automated tests
+- [ ] All new and existing tests pass

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,58 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels: []
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [oss-conduct@cisco.com][conduct-email]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+[conduct-email]: mailto:oss-conduct@cisco.com
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,83 +1,105 @@
-# Welcome to the KubeClarity Contributing Guide
+# How to Contribute
 
-Thank you for your interest in contributing to KubeClarity!
+Thanks for your interest in contributing to KubeClarity! Here are a few general guidelines on contributing and
+reporting bugs that we ask you to review. Following these guidelines helps to communicate that you respect the time of
+the contributors managing and developing this open source project. In return, they should reciprocate that respect in
+addressing your issue, assessing changes, and helping you finalize your pull requests. In that spirit of mutual respect,
+we endeavor to review incoming issues and pull requests within 10 days, and will close any lingering issues or pull
+requests after 60 days of inactivity.
 
-The following is a set of guidelines and instructions to help you:
+Please note that all of your interactions in the project are subject to our [Code of Conduct](/CODE_OF_CONDUCT.md). This
+includes creation of issues or pull requests, commenting on issues or pull requests, and extends to all interactions in
+any real-time space e.g., Slack, Discord, etc.
 
-- Submit a bug report or create a feature request
-- Build and test the KubeClarity code
-- Make a code change and submit a pull request
+## Table Of Contents
 
-If anything doesn't make sense or doesn't work when you run it please open an
-issue and let us know!
-
-## Table of Contents
-
-- [Getting Started](#getting-started)
-- [Code of Conduct](#code-of-conduct)
-- [Creating Issues](#creating-issues)
-  - [Submit a Bug Report](#submit-a-bug-report)
-  - [Submit a Feature Request](#submit-a-feature-request)
-- [Building and Testing KubeClarity](#building-and-testing-kubeclarity)
-  - [Building KubeClarity](#building-kubeclarity)
+- [Reporting Issues](#reporting-issues)
+- [Development](#development)
+  - [Generating API code](#generating-api-code)
+  - [Building KubeClarity Binaries](#building-kubeclarity-binaries)
+  - [Building KubeClarity Containers](#building-kubeclarity-containers)
+  - [Linting](#linting)
   - [Unit Tests](#unit-tests)
-  - [End to End Tests](#end-to-end-tests)
-- [Making Changes](#making-changes)
-  - [Exercising your change](#exercising-your-change)
-  - [Submitting a Change For Review](#submitting-a-change-for-review)
+  - [Testing End to End](#testing-end-to-end)
+- [Sending Pull Requests](#sending-pull-requests)
+- [Other Ways to Contribute](#other-ways-to-contribute)
 
-## Getting Started
+## Reporting Issues
 
-TODO
+Before reporting a new issue, please ensure that the issue was not already reported or fixed by searching through our
+[issues list](https://github.com/openclarity/kubeclarity/issues).
 
-## Code of Conduct
+When creating a new issue, please be sure to include a **title and clear description**, as much relevant information as
+possible, and, if possible, a test case.
 
-TODO
+**If you discover a security bug, please do not report it through GitHub. Instead, please see security procedures in
+[SECURITY.md](/SECURITY.md).**
 
-## Creating Issues
-
-TODO
-
-### Submit a Bug Report
-
-TODO
-
-### Submit a Feature Request
-
-TODO
-
-## Building and Testing KubeClarity
-
-TODO
+## Development
 
 ### Building KubeClarity
 
-TODO
+`make build` will build all of the KubeClarity code and UI.
 
-### Unit Tests
+Makefile targets are provided to compile and build the KubeClarity binaries.
+`make build-all-go` can be used to build all of the go components, but also
+specific targets are provided, for example `make cli` and `make backend` to
+build the specific components in isolation.
 
-To run all the unit tests locally a make target is provided:
+`make ui` is provided to just build the UI components.
 
-```shell
-make test
+### Building KubeClarity Containers
+
+`make docker` can be used to build the KubeClarity containers for all of the
+components. Specific targets for example `make docker-cli` and `make
+docker-backend` are also provided.
+
+`make push-docker` is also provided as a shortcut for building and then
+publishing the KubeClarity containers to a registry. You can override the
+destination registry like:
+
+```
+DOCKER_REGISTRY=docker.io/tehsmash make push-docker
 ```
 
-To run an individual test or test suite directly then you can go into the
-component directory and use `go test`:
+You must be logged into the docker registry locally before using this target.
 
-```shell
+### Linting
+
+`make lint` can be used to run the required linting rules over the code.
+golangci-lint rules and config can be viewed in the `.golangcilint` file in the
+root of the repo.
+
+`make fix` is also provided which will resolve lint issues which are
+automaticlly fixable for example format issues.
+
+`make license` can be used to validate that all the files in the repo have the
+correctly formatted license header.
+
+### Unit tests
+
+`make test` can be used run all the unit tests in the repo. Alternatively you
+can use the standard go test CLI to run a specific package or test by going
+into a specific modules directory and running:
+
+```
 cd cli
-go test ./...
+go test ./cmd/... -run <test name regex>
 ```
 
-### End to End Tests
+### Generating API code
+
+After making changes to the API schema for example `api/swagger.yaml`, you can run `make
+api` to regenerate the model, client and server code.
+
+### Testing End to End
 
 End to end tests will start and exercise a KubeClarity running on the local
 container runtime. This can be used locally or in CI. These tests ensure that
 more complex flows such as the CLI exporting results to the API work as
 expected.
 
-> ***Note***:  
+> ***Note***:
 > If running Docker Desktop for Mac you will need to increase docker daemon
 > memory to 8G. Careful, this will drain a lot from your computer cpu.
 
@@ -98,20 +120,26 @@ mv ./cli/bin/cli ./e2e/kubeclarity-cli
 make e2e
 ```
 
-## Making Changes
+## Sending Pull Requests
 
-TODO
+Before sending a new pull request, take a look at existing pull requests and issues to see if the proposed change or fix
+has been discussed in the past, or if the change was already implemented but not yet released.
 
-### Exercising a change
+We expect new pull requests to include tests for any affected behavior, and, as we follow semantic versioning, we may
+reserve breaking changes until the next major version release.
 
-While making a change to KubeClarity its worth testing locally to ensure that
-no regressions have been introduced and to ensure that everything is still
-working as expected. Its also good practise to test locally before submitting
-the code for review to prevent extra iterations on the PR due to failing CI
-testing. Please refer to the
-[Building and Testing KubeClarity](#building-and-testing-kubeclarity) section
-for more details.
+## Other Ways to Contribute
 
-### Submitting a Change for Review
+We welcome anyone that wants to contribute to KubeClarity to triage and reply to open issues to help troubleshoot
+and fix existing bugs. Here is what you can do:
 
-TODO
+- Help ensure that existing issues follows the recommendations from the _[Reporting Issues](#reporting-issues)_ section,
+  providing feedback to the issue's author on what might be missing.
+- Review and update the existing content of our [Wiki](https://github.com/openclarity/kubeclarity/wiki) with up-to-date
+  instructions and code samples.
+- Review existing pull requests, and testing patches against real existing applications that use KubeClarity.
+- Write a test, or add a missing test case to an existing test.
+
+Thanks again for your interest on contributing to KubeClarity!
+
+:heart:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the
+KubeClarity project.
+
+- [Reporting a Bug](#reporting-a-bug)
+- [Disclosure Policy](#disclosure-policy)
+- [Comments on this Policy](#comments-on-this-policy)
+
+## Reporting a Bug
+
+The KubeClarity team and community take all security bugs in
+KubeClarity seriously. Thank you for improving the security of
+KubeClarity. We appreciate your efforts and responsible disclosure and
+will make every effort to acknowledge your contributions.
+
+Report security bugs by emailing `oss-security@cisco.com`.
+
+The lead maintainer will acknowledge your email within 48 hours, and will send a
+more detailed response within 48 hours indicating the next steps in handling
+your report. After the initial reply to your report, the security team will
+endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+- Confirm the problem and determine the affected versions.
+- Audit code to find any potential similar problems.
+- Prepare fixes for all releases still under maintenance. These fixes will be
+  released as quickly as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.


### PR DESCRIPTION
This also enables the stalebot for managing old issues.