### PR TITLE
fix an index out of range in createDockleConfig

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,6 @@ In order to run end-to-end tests locally:
 # Build all docker images
 make docker
 # Replace Values In The KubeClarity Chart:
-sed -i 's/latest/v1.1/g' charts/kubeclarity/Chart.yaml
 sed -i 's/latest/${{ github.sha }}/g' charts/kubeclarity/values.yaml
 sed -i 's/Always/IfNotPresent/g' charts/kubeclarity/values.yaml
 # Build the KubeClarity CLI

--- a/cis_docker_benchmark_scanner/pkg/scanner/run.go
+++ b/cis_docker_benchmark_scanner/pkg/scanner/run.go
@@ -32,11 +32,17 @@ import (
 )
 
 func createDockleConfig(scanConfig *config.Config) *dockle_config.Config {
+	var username, password string
+	if len(scanConfig.Registry.Auths) > 0 {
+		username = scanConfig.Registry.Auths[0].Username
+		password = scanConfig.Registry.Auths[0].Password
+	}
+
 	return &dockle_config.Config{
 		Debug:     log.GetLevel() == log.DebugLevel,
 		Timeout:   scanConfig.Timeout,
-		Username:  scanConfig.Registry.Auths[0].Username,
-		Password:  scanConfig.Registry.Auths[0].Password,
+		Username:  username,
+		Password:  password,
 		Insecure:  scanConfig.Registry.SkipVerifyTLS,
 		NonSSL:    scanConfig.Registry.UseHTTP,
 		ImageName: scanConfig.ImageIDToScan,

--- a/e2e/common/api.go
+++ b/e2e/common/api.go
@@ -16,13 +16,13 @@
 package common
 
 import (
-	"github.com/openclarity/kubeclarity/api/client/models"
 	"testing"
 
 	"gotest.tools/assert"
 
 	"github.com/openclarity/kubeclarity/api/client/client"
 	"github.com/openclarity/kubeclarity/api/client/client/operations"
+	"github.com/openclarity/kubeclarity/api/client/models"
 )
 
 func PostApplications(t *testing.T, kubeclarityAPI *client.KubeClarityAPIs, applicationInfo *models.ApplicationInfo) *operations.PostApplicationsCreated {
@@ -32,6 +32,15 @@ func PostApplications(t *testing.T, kubeclarityAPI *client.KubeClarityAPIs, appl
 	assert.NilError(t, err)
 
 	return app
+}
+
+func PutRuntimeQuickScanConfig(t *testing.T, kubeclarityAPI *client.KubeClarityAPIs, config *models.RuntimeQuickScanConfig) *operations.PutRuntimeQuickscanConfigCreated {
+	t.Helper()
+	params := operations.NewPutRuntimeQuickscanConfigParams().WithBody(config)
+	res, err := kubeclarityAPI.Operations.PutRuntimeQuickscanConfig(params)
+	assert.NilError(t, err)
+
+	return res
 }
 
 func PutRuntimeScanStart(t *testing.T, kubeclarityAPI *client.KubeClarityAPIs, config *models.RuntimeScanConfig) *operations.PutRuntimeScanStartCreated {

--- a/e2e/curl_nginx.yaml
+++ b/e2e/curl_nginx.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: test
       containers:
         - name: nginx
-          image: nginx:1.21.6
+          image: nginx@sha256:859ab6768a6f26a79bc42b231664111317d095a4f04e4b6fe79ce37b3d199097 # nginx:1.21.6
           command: ["/bin/sleep", "10000000"]
           imagePullPolicy: IfNotPresent
 ---

--- a/e2e/curl_nginx.yaml
+++ b/e2e/curl_nginx.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: test
       containers:
         - name: nginx
-          image: nginx:1.10
+          image: nginx:1.21.6
           command: ["/bin/sleep", "10000000"]
           imagePullPolicy: IfNotPresent
 ---

--- a/e2e/runtime_scan_test.go
+++ b/e2e/runtime_scan_test.go
@@ -57,7 +57,7 @@ func TestRuntimeScan(t *testing.T) {
 			results := common.GetRuntimeScanResults(t, kubeclarityAPI)
 			resultsB, err := json.Marshal(results)
 			assert.NilError(t, err)
-			t.Logf("Got results %+v", string(resultsB))
+			t.Logf("Got runtime scan results: %+v", string(resultsB))
 
 			assert.Assert(t, results.Counters.Resources > 0)
 			assert.Assert(t, results.Counters.Vulnerabilities > 0)

--- a/e2e/runtime_scan_test.go
+++ b/e2e/runtime_scan_test.go
@@ -17,6 +17,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -52,8 +53,12 @@ func TestRuntimeScan(t *testing.T) {
 
 			t.Logf("get runtime scan results...")
 			// wait for refreshing materialized views
-			time.Sleep(common.WaitForMaterializedViewRefreshSecond * time.Second)
+			time.Sleep(common.WaitForMaterializedViewRefreshSecond * time.Second * 2)
 			results := common.GetRuntimeScanResults(t, kubeclarityAPI)
+			resultsB, err := json.Marshal(results)
+			assert.NilError(t, err)
+			t.Logf("Got results %+v", string(resultsB))
+
 			assert.Assert(t, results.Counters.Resources > 0)
 			assert.Assert(t, results.Counters.Vulnerabilities > 0)
 			assert.Assert(t, results.Counters.Packages > 0)
@@ -62,6 +67,7 @@ func TestRuntimeScan(t *testing.T) {
 			assert.Assert(t, results.CisDockerBenchmarkCounters.Applications > 0)
 
 			assert.Assert(t, len(results.VulnerabilityPerSeverity) > 0)
+			assert.Assert(t, len(results.CisDockerBenchmarkCountPerLevel) > 0)
 
 			// radial/busyboxplus:curl is not supported as it uses V1 image manifest, which should result in an error.
 			assert.Assert(t, len(results.Failures) > 0)

--- a/e2e/runtime_scan_test.go
+++ b/e2e/runtime_scan_test.go
@@ -58,6 +58,8 @@ func TestRuntimeScan(t *testing.T) {
 			assert.Assert(t, results.Counters.Vulnerabilities > 0)
 			assert.Assert(t, results.Counters.Packages > 0)
 			assert.Assert(t, results.Counters.Applications > 0)
+			assert.Assert(t, results.CisDockerBenchmarkCounters.Resources > 0)
+			assert.Assert(t, results.CisDockerBenchmarkCounters.Applications > 0)
 
 			assert.Assert(t, len(results.VulnerabilityPerSeverity) > 0)
 
@@ -92,6 +94,9 @@ func waitForScanDone(t *testing.T) error {
 
 func startRuntimeScan(t *testing.T) {
 	t.Helper()
+	_ = common.PutRuntimeQuickScanConfig(t, kubeclarityAPI, &models.RuntimeQuickScanConfig{
+		CisDockerBenchmarkScanEnabled: true,
+	})
 	_ = common.PutRuntimeScanStart(t, kubeclarityAPI, &models.RuntimeScanConfig{
 		Namespaces: []string{"test"},
 	})


### PR DESCRIPTION
## Description

Solve an index out of range crash in `createDockleConfig` when `scanConfig.Registry.Auths` is empty

## Type of Change

[X] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)
