### PR TITLE
Remove bullet list from "Type of Change" section in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,12 @@ change, which may lead to your PR taking much longer to review, or result in it 
 
 ## Type of Change
 
-- [ ] Bug Fix
-- [ ] New Feature
-- [ ] Breaking Change
-- [ ] Refactor
-- [ ] Documentation
-- [ ] Other (please describe)
+[ ] Bug Fix
+[ ] New Feature
+[ ] Breaking Change
+[ ] Refactor
+[ ] Documentation
+[ ] Other (please describe)
 
 ## Checklist
 


### PR DESCRIPTION
## Description

This results in a task list being generated for the PR which doesn't make sense because in most cases you aren't going to select all the options.

## Type of Change

[ ] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[X] Documentation
[ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
