### PR TITLE
tests: fix testdata file name to remove invalid char ':' when importing

### DIFF
--- a/shared/pkg/utils/gzip/gzip_test.go
+++ b/shared/pkg/utils/gzip/gzip_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestCompress(t *testing.T) {
-	file, err := os.ReadFile("testdata/examples-bookinfo-reviews-v1:1.17.0.cdx.json")
+	file, err := os.ReadFile("testdata/examples-bookinfo-reviews-v1-1.17.0.cdx.json")
 	assert.NilError(t, err)
 	t.Logf("file len %v", len(file))
 	compress, err := CompressAndEncode(file)


### PR DESCRIPTION
## Description

testdata file name with an invalid char ':' results with failures when trying to import the library.
```
	github.com/fatih/camelcase: github.com/openclarity/kubeclarity/shared@v0.0.0 (replaced by github.com/openclarity/kubeclarity/shared@v0.0.0-20230410132100-9c7c03567c82): verifying go.mod: github.com/openclarity/kubeclarity/shared@v0.0.0-20230410132100-9c7c03567c82/go.mod: reading https://sum.golang.org/lookup/github.com/openclarity/kubeclarity/shared@v0.0.0-20230410132100-9c7c03567c82: 404 Not Found
	server response: not found: create zip: pkg/utils/gzip/testdata/examples-bookinfo-reviews-v1:1.17.0.cdx.json: malformed file path "pkg/utils/gzip/testdata/examples-bookinfo-reviews-v1:1.17.0.cdx.json": invalid char ':'
```

This PR update the testdata file name

## Type of Change

[ ] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
