### PR TITLE
Check killSignal channel is closed

### DIFF
--- a/runtime_scan/pkg/scanner/scanner.go
+++ b/runtime_scan/pkg/scanner/scanner.go
@@ -498,7 +498,7 @@ func (s *Scanner) Clear() {
 	defer s.Unlock()
 
 	log.WithFields(s.logFields).Infof("Clearing...")
-	// Make sure that the channel is not closed
+	// Make sure to close the channel only once.
 	if !s.killChanClosed.Load() {
 		close(s.killSignal)
 		s.killChanClosed.Store(true)


### PR DESCRIPTION
## Description

Check if `killSignal` channel is closed to avoid panic calling close it twice.

## Type of Change

[x] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
