### PR TITLE
feat(grype): normalize matches by CVE

### DIFF
--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -233,7 +233,7 @@ kubeclarity-grype-server:
   ## Docker Image values.
   docker:
     imageRepo: "ghcr.io/openclarity"
-    imageTag: "v0.1.6"
+    imageTag: "v0.2.0"
     imagePullPolicy: Always
 
   ## Logging level (debug, info, warning, error, fatal, panic).

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -423,4 +423,6 @@ replace github.com/containerd/containerd => github.com/containerd/containerd v1.
 // Replace these for trivy
 replace oras.land/oras-go => oras.land/oras-go v1.1.1
 
+// /Users/idanf/go/pkg/mod/github.com/containers/image/v5@v5.19.0/sif/src.go:92:3: unknown field 'Architecture' in struct literal of type v1.Image
+// /Users/idanf/go/pkg/mod/github.com/containers/image/v5@v5.19.0/sif/src.go:93:3: unknown field 'OS' in struct literal of type v1.Image
 replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.1.0-rc2

--- a/shared/pkg/scanner/grype/common.go
+++ b/shared/pkg/scanner/grype/common.go
@@ -170,7 +170,12 @@ func getCVSS(match grype_models.Match) []scanner.CVSS {
 }
 
 func getCVSSFromMatch(match grype_models.Match) []grype_models.Cvss {
-	if len(match.RelatedVulnerabilities) != 0 {
+	// Due to NormalizeByCVE mode we prefer to get the info from the root if exists.
+	if len(match.Vulnerability.VulnerabilityMetadata.Cvss) != 0 {
+		return match.Vulnerability.VulnerabilityMetadata.Cvss
+	}
+
+	if len(match.RelatedVulnerabilities) != 0 && len(match.RelatedVulnerabilities[0].Cvss) > 0 {
 		return match.RelatedVulnerabilities[0].Cvss
 	}
 
@@ -178,6 +183,11 @@ func getCVSSFromMatch(match grype_models.Match) []grype_models.Cvss {
 }
 
 func getDescription(match grype_models.Match) string {
+	// Due to NormalizeByCVE mode we prefer to get the info from the root if exists.
+	if match.Vulnerability.Description != "" {
+		return match.Vulnerability.Description
+	}
+
 	if len(match.RelatedVulnerabilities) != 0 {
 		return match.RelatedVulnerabilities[0].Description
 	}

--- a/shared/pkg/scanner/grype/local_grype.go
+++ b/shared/pkg/scanner/grype/local_grype.go
@@ -119,7 +119,7 @@ func (s *LocalScanner) run(sourceType utils.SourceType, userInput string) {
 	vulnerabilityMatcher := createVulnerabilityMatcher(store)
 	allMatches, ignoredMatches, err := vulnerabilityMatcher.FindMatches(packages, context)
 	// We can ignore ErrAboveSeverityThreshold since we are not setting the FailSeverity on the matcher.
-	if err != nil && errors.Is(err, grypeerr.ErrAboveSeverityThreshold) {
+	if err != nil && !errors.Is(err, grypeerr.ErrAboveSeverityThreshold) {
 		ReportError(s.resultChan, fmt.Errorf("failed to find vulnerabilities: %w", err), s.logger)
 		return
 	}

--- a/shared/pkg/scanner/grype/local_grype.go
+++ b/shared/pkg/scanner/grype/local_grype.go
@@ -16,10 +16,12 @@
 package grype
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/anchore/grype/grype"
 	"github.com/anchore/grype/grype/db"
+	"github.com/anchore/grype/grype/grypeerr"
 	"github.com/anchore/grype/grype/matcher"
 	"github.com/anchore/grype/grype/matcher/dotnet"
 	"github.com/anchore/grype/grype/matcher/golang"
@@ -30,6 +32,7 @@ import (
 	"github.com/anchore/grype/grype/matcher/stock"
 	"github.com/anchore/grype/grype/pkg"
 	grype_models "github.com/anchore/grype/grype/presenter/models"
+	"github.com/anchore/grype/grype/store"
 	"github.com/anchore/syft/syft/pkg/cataloger"
 	log "github.com/sirupsen/logrus"
 
@@ -113,6 +116,26 @@ func (s *LocalScanner) run(sourceType utils.SourceType, userInput string) {
 
 	s.logger.Infof("Found %d packages", len(packages))
 
+	vulnerabilityMatcher := createVulnerabilityMatcher(store)
+	allMatches, ignoredMatches, err := vulnerabilityMatcher.FindMatches(packages, context)
+	// We can ignore ErrAboveSeverityThreshold since we are not setting the FailSeverity on the matcher.
+	if err != nil && errors.Is(err, grypeerr.ErrAboveSeverityThreshold) {
+		ReportError(s.resultChan, fmt.Errorf("failed to find vulnerabilities: %w", err), s.logger)
+		return
+	}
+
+	s.logger.Infof("Found %d vulnerabilities", len(allMatches.Sorted()))
+	doc, err := grype_models.NewDocument(packages, context, *allMatches, ignoredMatches, store.MetadataProvider, nil, dbStatus)
+	if err != nil {
+		ReportError(s.resultChan, fmt.Errorf("failed to create document: %w", err), s.logger)
+		return
+	}
+
+	s.logger.Infof("Sending successful results")
+	s.resultChan <- CreateResults(doc, origInput, ScannerName, hash)
+}
+
+func createVulnerabilityMatcher(store *store.Store) *grype.VulnerabilityMatcher {
 	matchers := matcher.NewDefaultMatchers(matcher.Config{
 		Java: java.MatcherConfig{
 			ExternalSearchConfig: java.ExternalSearchConfig{
@@ -141,17 +164,11 @@ func (s *LocalScanner) run(sourceType utils.SourceType, userInput string) {
 			UseCPEs: true,
 		},
 	})
-
-	allMatches := grype.FindVulnerabilitiesForPackage(*store, context.Distro, matchers, packages)
-	s.logger.Infof("Found %d vulnerabilities", len(allMatches.Sorted()))
-	doc, err := grype_models.NewDocument(packages, context, allMatches, nil, store.MetadataProvider, nil, dbStatus)
-	if err != nil {
-		ReportError(s.resultChan, fmt.Errorf("failed to create document: %w", err), s.logger)
-		return
+	return &grype.VulnerabilityMatcher{
+		Store:          *store,
+		Matchers:       matchers,
+		NormalizeByCVE: true,
 	}
-
-	s.logger.Infof("Sending successful results")
-	s.resultChan <- CreateResults(doc, origInput, ScannerName, hash)
 }
 
 func validateDBLoad(loadErr error, status *db.Status) error {


### PR DESCRIPTION
## Description

The PR is setting the `NormalizeByCVE` to true in grype `VulnerabilityMatcher` to orient results by CVE instead of the original vulnerability ID when possible.
Also, replacing the `FindVulnerabilitiesForPackage` deprecated function in grype.

## Type of Change

[ ] Bug Fix
[X] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
