### PR TITLE
Add a support to set the default scanners namepace

### DIFF
--- a/charts/kubeclarity/templates/scanner-template-configmap.yaml
+++ b/charts/kubeclarity/templates/scanner-template-configmap.yaml
@@ -17,6 +17,7 @@ data:
     apiVersion: batch/v1
     kind: Job
     metadata:
+      namespace: {{ index .Values "kubeclarity-runtime-scan" "namespace" | quote }}
       labels:
 {{- toYaml (index .Values "kubeclarity-runtime-scan" "labels") | nindent 8 }}
     spec:

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -118,6 +118,12 @@ kubeclarity-runtime-scan:
     app: kubeclarity-scanner
     sidecar.istio.io/inject: "false"
 
+  ## Scanner jobs namespace.
+  # If set, the scanner jobs will run in the given namespace unless:
+  # 1. The scanner job must run in the pod namespace to fetch image pull secrets, OR
+  # 2. The scanner job must run in the release namespace to fetch service credentials (more info in https://github.com/openclarity/kubeclarity#private-registries-support-for-k8s-runtime-scan)
+  namespace: ""
+
   ## Scanner pods tolerations.
   # tolerations:
   # - key: key1

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -119,6 +119,7 @@ kubeclarity-runtime-scan:
     sidecar.istio.io/inject: "false"
 
   ## Scanner jobs namespace.
+  # If left blank, the scanner jobs will run in the same namespace as pod being scanned.
   # If set, the scanner jobs will run in the given namespace unless:
   # 1. The scanner job must run in the pod namespace to fetch image pull secrets, OR
   # 2. The scanner job must run in the release namespace to fetch service credentials (more info in https://github.com/openclarity/kubeclarity#private-registries-support-for-k8s-runtime-scan)


### PR DESCRIPTION
## Description

The PR adds a support to be able to set the default namespace where job scanners should run.
If a default value is set it may be overridden if:
1. The scanner job must run in the pod namespace to fetch image pull secrets, OR
2. The scanner job must run in the release namespace to fetch service credentials (more info in https://github.com/openclarity/kubeclarity#private-registries-support-for-k8s-runtime-scan)

Solves https://github.com/openclarity/kubeclarity/issues/389

## Type of Change

[ ] Bug Fix
[X] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
