### PR TITLE
Update dependency track swagger specification

### DIFF
--- a/shared/pkg/scanner/dependency_track/api/client/models/vulnerability.go
+++ b/shared/pkg/scanner/dependency_track/api/client/models/vulnerability.go
@@ -75,7 +75,8 @@ type Vulnerability struct {
 	PatchedVersions string `json:"patchedVersions,omitempty"`
 
 	// published
-	Published float64 `json:"published,omitempty"`
+	// Format: date-time
+	Published strfmt.DateTime `json:"published,omitempty"`
 
 	// recommendation
 	Recommendation string `json:"recommendation,omitempty"`
@@ -102,7 +103,8 @@ type Vulnerability struct {
 	Title string `json:"title,omitempty"`
 
 	// updated
-	Updated float64 `json:"updated,omitempty"`
+	// Format: date-time
+	Updated strfmt.DateTime `json:"updated,omitempty"`
 
 	// uuid
 	// Required: true
@@ -141,6 +143,10 @@ func (m *Vulnerability) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validatePublished(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateServiceComponents(formats); err != nil {
 		res = append(res, err)
 	}
@@ -150,6 +156,10 @@ func (m *Vulnerability) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateSource(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateUpdated(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -245,6 +255,18 @@ func (m *Vulnerability) validateFriendlyVulnID(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *Vulnerability) validatePublished(formats strfmt.Registry) error {
+	if swag.IsZero(m.Published) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("published", "body", "date-time", m.Published.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *Vulnerability) validateServiceComponents(formats strfmt.Registry) error {
 	if swag.IsZero(m.ServiceComponents) { // not required
 		return nil
@@ -333,6 +355,18 @@ func (m *Vulnerability) validateSource(formats strfmt.Registry) error {
 	}
 
 	if err := validate.MaxLength("source", "body", m.Source, 255); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Vulnerability) validateUpdated(formats strfmt.Registry) error {
+	if swag.IsZero(m.Updated) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("updated", "body", "date-time", m.Updated.String(), formats); err != nil {
 		return err
 	}
 

--- a/shared/pkg/scanner/dependency_track/api/swagger.yaml
+++ b/shared/pkg/scanner/dependency_track/api/swagger.yaml
@@ -666,9 +666,11 @@ definitions:
       created:
         type: number
       published:
-        type: number
+        type: string
+        format: date-time
       updated:
-        type: number
+        type: string
+        format: date-time
       cwe:
         $ref: '#/definitions/Cwe'
       cvssV2BaseScore:


### PR DESCRIPTION
## Description


Scan using dependency_track integration fails, e.g.:
```
SCANNER_DEPENDENCY_TRACK_DISABLE_TLS=true \
SCANNER_DEPENDENCY_TRACK_HOST=dependency-track-apiserver.dependency-track \
SCANNER_DEPENDENCY_TRACK_API_KEY=XXX \
 ./cli scan nginx.sbom -i sbom
...
ERRO[0150] failed to get vulnerabilities result: failed to get vulnerabilities by project: json: cannot unmarshal string into Go struct field Vulnerability.published of type float64  app=kubeclarity scanner=dependency-track
...
````
This is minimal changes to fix dependency_track scanner integration.

## Type of Change

[X] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
