### PR TITLE
Repository Onboarding Prep

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -8,7 +8,7 @@ repository:
   description: KubeClarity is a tool for detection and management of Software Bill Of Materials (SBOM) and vulnerabilities of container images and filesystems
 
   # A URL with more information about the repository
-  homepage: https://www.portshift.io/blog/kubernetes-runtime-vulnerabilities-scanner-launch/
+  homepage: https://openclarity.io
 
   # Updates the default branch for this repository.
   default_branch: main

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 90
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 14
+daysUntilClose: 30
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -28,11 +28,9 @@ staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has no recent
-  activity in the last 60 days. It will be closed in 14 days if no further
-  activity occurs. If this issue is still relevant please leave a comment to
-  let us know and the stale label will be automatically removed. Thank you for
-  your contributions.
+  Thank you for your contribution! Since there hasn't been any recent activity,
+  this issue has been automatically marked as stale, and may eventually be closed.
+  Please bump this issue by leaving a comment if you want to keep it open.
 
 # Comment to post when removing the stale label.
 # unmarkComment: >
@@ -40,8 +38,8 @@ markComment: >
 
 # Comment to post when closing a stale Issue or Pull Request.
 closeComment: >
-  This issue has been stale for 14 days and is now closed due to inactivity, if
-  this issue is still relevant please re-open this issue, or open a new issue.
+  This stale issue is now closed due to inactivity. Please re-open or re-file if
+  if the issue is still relevant. Thank you!
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30


### PR DESCRIPTION
These changes will help prepare this repository to onboard contributors who are new to open source, and may need extra time and guidance in order to make their first contributions. 

This will be done in concert with an audit of existing open project issues, in order to determine whether any existing issues need to be unmarked as `stale`, or labeled as `good first issue`. 

After identifying a few good issues, we can direct participants to **[/contribute](https://github.com/openclarity/kubeclarity/contribute)** to find a curated list of issues, as well as a link to the `CONTRIBUTING.md` guidelines.

## Changes

* Repository configuration settings (`.github/settings.yml`)
* Stalebot issue settings + phrasing (`.github/stalebot.yml`)