### PR TITLE
Add min value validation on Max Scan Parallelism field

### DIFF
--- a/ui/src/components/Form/form-fields/TextField/index.js
+++ b/ui/src/components/Form/form-fields/TextField/index.js
@@ -11,7 +11,7 @@ const TextField = ({className, small=false, label, disabled, tooltipText, type="
     return (
         <div className={classnames("form-field-wrapper", "text-field", {small}, className)}>
             {!!label && <FieldLabel tooltipId={`form-tooltip-${field.name}`} tooltipText={tooltipText}>{label}</FieldLabel>}
-            <input type={type} {...field} className="form-field" disabled={disabled} />
+            <input type={type} {...field} className="form-field" disabled={disabled} {...(props.min && { "min": props.min })} />
             {meta.touched && meta.error && <FieldError>{meta.error}</FieldError>}
         </div>
     )

--- a/ui/src/components/Form/validators.js
+++ b/ui/src/components/Form/validators.js
@@ -3,3 +3,7 @@ import { isEmpty, isNumber } from 'lodash';
 export const validateRequired = value => (
     isEmpty(value) && !isNumber(value) && value !== 0 ? "This field is required" : undefined
 );
+
+export const validateMaxScanField = value => (
+    value < 0 ? "Should be greater than or equal to 1" : undefined   
+);

--- a/ui/src/layout/RuntimeScan/ScanConfiguration/ScanOptionsForm.js
+++ b/ui/src/layout/RuntimeScan/ScanConfiguration/ScanOptionsForm.js
@@ -36,7 +36,7 @@ const ScanOptionsForm = ({onClose}) => {
                     })}
                 >
                     <ToggleField name="cisDockerBenchmarkScanEnabled" label="CIS Docker Benchmark" />
-                    <TextField name="maxScanParallelism" label="Max Scan Parallelism" type="number" />
+                    <TextField name="maxScanParallelism" label="Max Scan Parallelism" type="number" min="0" />
                 </FormWrapper>
             }
         </Modal>

--- a/ui/src/layout/RuntimeScan/ScanConfiguration/ScanOptionsForm.js
+++ b/ui/src/layout/RuntimeScan/ScanConfiguration/ScanOptionsForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FETCH_METHODS, useFetch } from 'hooks';
-import FormWrapper, { ToggleField, TextField } from 'components/Form';
+import FormWrapper, { ToggleField, TextField, validators } from 'components/Form';
 import Modal from 'components/Modal';
 import Loader from 'components/Loader';
 
@@ -36,7 +36,13 @@ const ScanOptionsForm = ({onClose}) => {
                     })}
                 >
                     <ToggleField name="cisDockerBenchmarkScanEnabled" label="CIS Docker Benchmark" />
-                    <TextField name="maxScanParallelism" label="Max Scan Parallelism" type="number" min="1" />
+                    <TextField 
+                        name="maxScanParallelism" 
+                        label="Max Scan Parallelism" 
+                        type="number" 
+                        validate={validators.validateMaxScanField}
+                        min="1" 
+                    />
                 </FormWrapper>
             }
         </Modal>

--- a/ui/src/layout/RuntimeScan/ScanConfiguration/ScanOptionsForm.js
+++ b/ui/src/layout/RuntimeScan/ScanConfiguration/ScanOptionsForm.js
@@ -36,7 +36,7 @@ const ScanOptionsForm = ({onClose}) => {
                     })}
                 >
                     <ToggleField name="cisDockerBenchmarkScanEnabled" label="CIS Docker Benchmark" />
-                    <TextField name="maxScanParallelism" label="Max Scan Parallelism" type="number" min="0" />
+                    <TextField name="maxScanParallelism" label="Max Scan Parallelism" type="number" min="1" />
                 </FormWrapper>
             }
         </Modal>

--- a/ui/src/layout/RuntimeScan/ScanConfiguration/ScheduleScanForm/index.js
+++ b/ui/src/layout/RuntimeScan/ScanConfiguration/ScheduleScanForm/index.js
@@ -35,7 +35,13 @@ const FormFields = ({namespaces}) => {
                 items={namespaces}
             />
             <ToggleField name={GENERAL_FOMR_FIELDS.CIS_ENABLED} label="CIS Docker Benchmark" />
-            <TextField name={GENERAL_FOMR_FIELDS.MAX_SCANPARALLELISM} label="Max Scan Parallelism" type="number" />
+            <TextField 
+                name={GENERAL_FOMR_FIELDS.MAX_SCANPARALLELISM} 
+                label="Max Scan Parallelism" 
+                type="number" 
+                validate={validators.validateMaxScanField} 
+                min="1" 
+            />
             <SelectField
                 name={`${SCHEDULE_TYPE_DATA_WRAPPER}.${GENERAL_FOMR_FIELDS.SCHEDULE_TYPE}`}
                 label="Scan time"


### PR DESCRIPTION
## Description

Initially the UI allowed negative entries to be entered in the Max Scan Parallelism (under the scan configuration). This is not valid since negative numbers for parallelism  (e.g. Max Scan Parallelism = -20) do not make sense and are not valid according to the API spec. After this change, UI will allow only positive entries to be entered. This fixes #441.

## Type of Change

[x] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
