### PR TITLE
avoid duplicate image pull secrets

### DIFF
--- a/runtime_scan/pkg/scanner/scanner.go
+++ b/runtime_scan/pkg/scanner/scanner.go
@@ -208,6 +208,7 @@ func (s *Scanner) initScan() error {
 		for _, ips := range pod.Spec.ImagePullSecrets {
 			// avoid cases where a pod has the same imagePullSecret more than once.
 			if _, ok := imagePullSecretNamesSet[ips.Name]; ok {
+				log.WithFields(s.logFields).Warnf("Duplicate image pull secret name: %v", ips.Name)
 				continue
 			}
 			imagePullSecretNamesSet[ips.Name] = struct{}{}

--- a/runtime_scan/pkg/scanner/scanner.go
+++ b/runtime_scan/pkg/scanner/scanner.go
@@ -204,7 +204,13 @@ func (s *Scanner) initScan() error {
 		// inform the scanner where to check for credentials to pull
 		// the image to scan.
 		imagePullSecretNames := []string{}
+		var imagePullSecretNamesSet map[string]struct{}
 		for _, ips := range pod.Spec.ImagePullSecrets {
+			// avoid cases where a pod has the same imagePullSecret more than once.
+			if _, ok := imagePullSecretNamesSet[ips.Name]; ok {
+				continue
+			}
+			imagePullSecretNamesSet[ips.Name] = struct{}{}
 			imagePullSecretNames = append(imagePullSecretNames, ips.Name)
 		}
 

--- a/runtime_scan/pkg/scanner/scanner.go
+++ b/runtime_scan/pkg/scanner/scanner.go
@@ -204,7 +204,7 @@ func (s *Scanner) initScan() error {
 		// inform the scanner where to check for credentials to pull
 		// the image to scan.
 		imagePullSecretNames := []string{}
-		var imagePullSecretNamesSet map[string]struct{}
+		imagePullSecretNamesSet := make(map[string]struct{})
 		for _, ips := range pod.Spec.ImagePullSecrets {
 			// avoid cases where a pod has the same imagePullSecret more than once.
 			if _, ok := imagePullSecretNamesSet[ips.Name]; ok {


### PR DESCRIPTION
## Description

avoid injecting the same volumeMount path.
It can happen if the list of imagePullSecrets on the pod holds the same secret name more than once.

## Type of Change

[ *] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

