### PR TITLE
Add granular permissions to GitHub action workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  packages: write
+
 jobs:
   build_and_push:
     uses: ./.github/workflows/reusable-build-and-push.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,10 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  packages: write
+  contents: write
+
 env:
   GO_VERSION: 1.19
 


### PR DESCRIPTION
## Description

This commit adds granular permissions to the workflows that need them to perform their tasks.

The release action needs access to the "contents" of a repo in order to create a release, and requires access to packages in order to publish the containers.

The docker action only needs access to packages to publish the "latest" build from the main branch.

## Type of Change

[ ] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[X] Other (please describe) CI/CD

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
