### PR TITLE
Changed service port to dynamic

### DIFF
--- a/charts/kubeclarity/templates/service.yaml
+++ b/charts/kubeclarity/templates/service.yaml
@@ -12,9 +12,9 @@ spec:
   type: {{ .Values.kubeclarity.service.type }}
   ports:
     - name: backend
-      port: 8080
+      port: {{ .Values.kubeclarity.service.port }}
       protocol: TCP
-      targetPort: 8080
+      targetPort: {{ .Values.kubeclarity.service.targetPort }}
     - name: runtime-scan-results
       port: {{ index .Values "kubeclarity-runtime-scan" "resultServicePort" }}
       protocol: TCP


### PR DESCRIPTION
## Description

I want to change backend ports and targetport, but these are hardcoded, I am making it dynamic in template/service.yaml.
```yaml
spec:
  type: {{ .Values.kubeclarity.service.type }}
  ports:
    - name: backend
      port: 8080
      protocol: TCP
      targetPort: 8080
```
when we insert: 8080 in DNS means that your service is listening on port 8080
but port 80 is used when you don't insert any port in DNS. I changed the service port from hard coded to dynamic.

## Type of Change

[:heavy_check_mark:] New Feature

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code-style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
