### PR TITLE
Helm: Support affinity for kubeclarity / sbom / grype

### DIFF
--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "kubeclarity.name" . }}
+{{- if .Values.kubeclarity.affinity }}
+      affinity:
+{{ toYaml .Values.kubeclarity.affinity | indent 8 }}
+{{- end }}
       initContainers:
         - name: '{{ include "kubeclarity.name" . }}-wait-for-pg-db'
           image: {{ index .Values "kubeclarity-postgresql" "image" "registry" }}/{{ index .Values "kubeclarity-postgresql" "image" "repository" }}:{{ index .Values "kubeclarity-postgresql" "image" "tag" }}

--- a/charts/kubeclarity/templates/grype_server/deployment.yaml
+++ b/charts/kubeclarity/templates/grype_server/deployment.yaml
@@ -24,6 +24,10 @@ spec:
       securityContext:
         fsGroup: 1000
       {{- end }}
+{{- if (index .Values "kubeclarity-grype-server" "affinity") }}
+      affinity:
+{{ toYaml (index .Values "kubeclarity-grype-server" "affinity") | indent 8 }}
+{{- end }}
       containers:
         - name: grype-server
           image: '{{ index .Values "kubeclarity-grype-server" "docker" "imageRepo" }}/grype-server:{{ index .Values "kubeclarity-grype-server" "docker" "imageTag" }}'

--- a/charts/kubeclarity/templates/sbom_db/deployment.yaml
+++ b/charts/kubeclarity/templates/sbom_db/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       securityContext:
         fsGroup: 1000
       {{- end }}
+{{- if (index .Values "kubeclarity-grype-server" "affinity") }}
+      affinity:
+{{ toYaml (index .Values "kubeclarity-grype-server" "affinity") | indent 8 }}
+{{- end }}
       containers:
         - name: sbom-db
           {{- if index .Values "kubeclarity-sbom-db" "docker" "imageName" }}

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -106,6 +106,10 @@ kubeclarity:
         memory: "200Mi"
         cpu: "200m"
 
+  ## Affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
 ## End of KubeClarity Values
 #######################################################################################
 
@@ -260,6 +264,10 @@ kubeclarity-grype-server:
       cpu: "1000m"
       memory: "1G"
 
+  ## Affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
 ## End of KubeClarity Grype Server Values
 #######################################################################################
 
@@ -329,6 +337,10 @@ kubeclarity-sbom-db:
     limits:
       memory: "1Gi"
       cpu: "200m"
+
+  ## Affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
 
 ## End of KubeClarity SBOM DB Values
 #######################################################################################


### PR DESCRIPTION
## Description

The current helm chart doesn't allow configuring either `nodeSelector` or `nodeAffinity` (or `podAffinity` for that matter).

This is a particular problem in heterogeneous clusters where you may have Windows or ARM nodes which kubeclarity can't run on.

Adds an open `affinity` value to kubeclarity / sbom / grype to allow arbitrary node / pod affinity configuration.

e.g. 
```yaml
kubeclarity:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux
          - key: kubernetes.io/arch
            operator: In
            values:
            - amd64
```

n.b. The Trivy and Postgres sub-charts already support affinity configuration.

## Type of Change

- [x] New Feature

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented - in `values.yaml`
- [ ] All code style checks pass - no tests for the helm chart unless I've missed them?
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
