### PR TITLE
Made kubeclarity service port and targetport to dynamic

### DIFF
--- a/charts/kubeclarity/templates/service.yaml
+++ b/charts/kubeclarity/templates/service.yaml
@@ -12,9 +12,9 @@ spec:
   type: {{ .Values.kubeclarity.service.type }}
   ports:
     - name: backend
-      port: 8080
+      port: {{ .Values.kubeclarity.service.port }}
       protocol: TCP
-      targetPort: 8080
+      targetPort: {{ .Values.kubeclarity.service.targetPort }}
     - name: runtime-scan-results
       port: {{ index .Values "kubeclarity-runtime-scan" "resultServicePort" }}
       protocol: TCP

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -59,6 +59,8 @@ kubeclarity:
 
   service:
     type: ClusterIP
+    port: 80
+    targetPort: 8080
     annotations: {}
 
   ingress:


### PR DESCRIPTION
## Description
I want to change kubeclarity service backend ports and targetport, but these are hardcoded, I am making it dynamic in template/service.yaml.
```yaml
spec:
  type: {{ .Values.kubeclarity.service.type }}
  ports:
    - name: backend
      port: 8080
      protocol: TCP
      targetPort: 8080
```

- when we insert port 8080 in DNS means that our service is listening on port 8080 but port 80 is used when you don't insert any port in DNS. 
- I want the service port 80 so that we just need to browse Load Balancer DNS in the browser without giving port with DNS(DNS:8080) to access the kubeclarity UI, but service port and target port was hardcoded.
- I changed the service port from hard coded to dynamic so that we can give any port for kubeclarity service as per our convenience.

## Type of Change

[ ] Bug Fix
[:heavy_check_mark:] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
