### PR TITLE
custom schemes available from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,12 @@ docker run -p 9991:9991 --rm gcr.io/eticloud/k8sec/grype-server:v0.1.5
 
 To run a scan using the server:
 ```
-SCANNERS_LIST="grype" SCANNER_GRYPE_MODE="remote" SCANNER_REMOTE_GRYPE_SERVER_ADDRESS="<grype server address>:9991" ./kubeclarity_cli scan --input-type sbom nginx.sbom
+SCANNERS_LIST="grype" SCANNER_GRYPE_MODE="remote" SCANNER_REMOTE_GRYPE_SERVER_ADDRESS="<grype server address>:9991" SCANNER_REMOTE_GRYPE_SERVER_SCHEMES="https" ./kubeclarity_cli scan --input-type sbom nginx.sbom
+```
+
+If Grype server is deployed with TLS you can override the default URL scheme like:
+```
+SCANNERS_LIST="grype" SCANNER_GRYPE_MODE="remote" SCANNER_REMOTE_GRYPE_SERVER_ADDRESS="<grype server address>:9991" SCANNER_REMOTE_GRYPE_SERVER_SCHEMES="https" ./kubeclarity_cli scan --input-type sbom nginx.sbom
 ```
 
 ### Dependency Track

--- a/shared/pkg/config/remote_grype.go
+++ b/shared/pkg/config/remote_grype.go
@@ -23,11 +23,13 @@ import (
 
 const (
 	ScannerRemoteGrypeServerAddress = "SCANNER_REMOTE_GRYPE_SERVER_ADDRESS"
+	ScannerRemoteGrypeServerSchemes = "SCANNER_REMOTE_GRYPE_SERVER_SCHEMES"
 	ScannerRemoteGrypeServerTimeout = "SCANNER_REMOTE_GRYPE_SERVER_TIMEOUT"
 )
 
 type RemoteGrypeConfig struct {
 	GrypeServerAddress string        `yaml:"grype_server_address" mapstructure:"grype_server_address"`
+	GrypeServerSchemes []string      `yaml:"grype_server_schemes" mapstructure:"grype_server_schemes"`
 	GrypeServerTimeout time.Duration `yaml:"grype_server_timeout" mapstructure:"grype_server_timeout"`
 }
 
@@ -35,11 +37,13 @@ func loadRemoteGrypeConfig() RemoteGrypeConfig {
 	setRemoteGrypeScannerConfigDefaults()
 	return RemoteGrypeConfig{
 		GrypeServerAddress: viper.GetString(ScannerRemoteGrypeServerAddress),
+		GrypeServerSchemes: []string{viper.GetString(ScannerRemoteGrypeServerSchemes)},
 		GrypeServerTimeout: viper.GetDuration(ScannerRemoteGrypeServerTimeout),
 	}
 }
 
 func setRemoteGrypeScannerConfigDefaults() {
 	viper.SetDefault(ScannerRemoteGrypeServerAddress, "kubeclarity-grype-server.kubeclarity:9991")
+	viper.SetDefault(ScannerRemoteGrypeServerSchemes, []string{"http"})
 	viper.SetDefault(ScannerRemoteGrypeServerTimeout, 2*time.Minute) // nolint:gomnd
 }

--- a/shared/pkg/config/remote_grype.go
+++ b/shared/pkg/config/remote_grype.go
@@ -37,7 +37,7 @@ func loadRemoteGrypeConfig() RemoteGrypeConfig {
 	setRemoteGrypeScannerConfigDefaults()
 	return RemoteGrypeConfig{
 		GrypeServerAddress: viper.GetString(ScannerRemoteGrypeServerAddress),
-		GrypeServerSchemes: []string{viper.GetString(ScannerRemoteGrypeServerSchemes)},
+		GrypeServerSchemes: viper.GetStringSlice(ScannerRemoteGrypeServerSchemes),
 		GrypeServerTimeout: viper.GetDuration(ScannerRemoteGrypeServerTimeout),
 	}
 }

--- a/shared/pkg/scanner/grype/remote_grype.go
+++ b/shared/pkg/scanner/grype/remote_grype.go
@@ -44,7 +44,7 @@ type RemoteScanner struct {
 }
 
 func newRemoteScanner(conf *config.Config, logger *log.Entry, resultChan chan job_manager.Result) job_manager.Job {
-	cfg := grype_client.DefaultTransportConfig().WithHost(conf.Scanner.GrypeConfig.GrypeServerAddress)
+	cfg := grype_client.DefaultTransportConfig().WithSchemes(conf.Scanner.GrypeConfig.GrypeServerSchemes).WithHost(conf.Scanner.GrypeConfig.GrypeServerAddress)
 
 	return &RemoteScanner{
 		logger:     logger.Dup().WithField("scanner", ScannerName).WithField("scanner-mode", "remote"),


### PR DESCRIPTION
## Description

I would like to be able to work with HTTPS remote Grype server. My change adds the option to configure https through: SCANNER_REMOTE_GRYPE_SERVER_SCHEMES

## Type of Change

[ ] Bug Fix
[*] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [*] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [*] Existing issues have been referenced (where applicable)
- [*] I have verified this change is not present in other open pull requests
- [*] Functionality is documented
- [*] All code style checks pass
- [*] New code contribution is covered by automated tests
- [*] All new and existing tests pass
