### PR TITLE
fix(syft): get hash from repo or manifest digest to support local images

### DIFF
--- a/shared/pkg/analyzer/syft/syft.go
+++ b/shared/pkg/analyzer/syft/syft.go
@@ -126,10 +126,7 @@ func (a *Analyzer) setError(res *analyzer.Results, err error) {
 func getImageHash(sbom syft_sbom.SBOM, src string) (string, error) {
 	switch metadata := sbom.Source.Metadata.(type) {
 	case source.StereoscopeImageSourceMetadata:
-		if metadata.RepoDigests == nil {
-			metadata.RepoDigests = []string{}
-		}
-		return image_helper.GetHashFromRepoDigest(metadata.RepoDigests, src), nil
+		return image_helper.GetHashFromRepoOrManifestDigest(metadata.RepoDigests, metadata.ManifestDigest, src), nil
 	default:
 		return "", fmt.Errorf("failed to get image hash from source metadata")
 	}

--- a/shared/pkg/scanner/grype/common.go
+++ b/shared/pkg/scanner/grype/common.go
@@ -119,14 +119,7 @@ func getSource(doc grype_models.Document, userInput, hash string) scanner.Source
 		if hash != "" {
 			break
 		}
-		hash = image_helper.GetHashFromRepoDigest(imageMetadata.RepoDigests, userInput)
-		if hash == "" {
-			// set hash using ManifestDigest if RepoDigest is missing
-			manifestHash := imageMetadata.ManifestDigest
-			if idx := strings.Index(manifestHash, ":"); idx != -1 {
-				hash = manifestHash[idx+1:]
-			}
-		}
+		hash = image_helper.GetHashFromRepoOrManifestDigest(imageMetadata.RepoDigests, imageMetadata.ManifestDigest, userInput)
 	case string:
 		srcName = doc.Source.Target.(string) // nolint:forcetypeassert
 	}

--- a/shared/pkg/utils/image_helper/image_helper.go
+++ b/shared/pkg/utils/image_helper/image_helper.go
@@ -218,3 +218,16 @@ func GetImageLayerCommands(imageName string, sharedConf *sharedconfig.Config) ([
 	}
 	return layerCommands, nil
 }
+
+func GetHashFromRepoOrManifestDigest(repoDigests []string, manifestDigest string, imageName string) string {
+	hash := GetHashFromRepoDigest(repoDigests, imageName)
+	if hash == "" {
+		// set hash using ManifestDigest if RepoDigest is missing
+		if idx := strings.Index(manifestDigest, ":"); idx != -1 {
+			hash = manifestDigest[idx+1:]
+		} else {
+			hash = manifestDigest
+		}
+	}
+	return hash
+}

--- a/shared/pkg/utils/image_helper/image_helper_test.go
+++ b/shared/pkg/utils/image_helper/image_helper_test.go
@@ -85,6 +85,66 @@ func TestGetRepoDigest(t *testing.T) {
 	}
 }
 
+func TestGetHashFromRepoOrManifestDigest(t *testing.T) {
+	type args struct {
+		repoDigests    []string
+		manifestDigest string
+		imageName      string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "RepoDigests is not missing",
+			args: args{
+				manifestDigest: "sha256:38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
+				repoDigests: []string{
+					"debian@sha256:2906804d2a64e8a13a434a1a127fe3f6a28bf7cf3696be4223b06276f32f1f2d",
+					"poke/debian@sha256:a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
+				},
+				imageName: "poke/debian:latest",
+			},
+			want: "a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
+		},
+		{
+			name: "RepoDigests is missing",
+			args: args{
+				manifestDigest: "sha256:38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
+				repoDigests:    nil,
+				imageName:      "poke/debian:latest",
+			},
+			want: "38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
+		},
+		{
+			name: "RepoDigests is missing, manifestDigest is missing :",
+			args: args{
+				manifestDigest: "38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
+				repoDigests:    nil,
+				imageName:      "poke/debian:latest",
+			},
+			want: "38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
+		},
+		{
+			name: "Both RepoDigests and ManifestDigest is missing",
+			args: args{
+				manifestDigest: "",
+				repoDigests:    nil,
+				imageName:      "poke/debian:latest",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetHashFromRepoOrManifestDigest(tt.args.repoDigests, tt.args.manifestDigest, tt.args.imageName); got != tt.want {
+				t.Errorf("GetHashFromRepoOrManifestDigest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_stripDockerMetaFromCommand(t *testing.T) {
 	type args struct {
 		command string


### PR DESCRIPTION
## Description

The PR fixes an issue with local images sbom generation.
Following syft update in https://github.com/anchore/syft/pull/1846/files#diff-2a232ddbaede1f8b49a67d5e38d543dc3bf7869661f6910ce00dc6a024af6b75, when a local image was scanned, the manifest digest is now missing in the `version`.
There was a need to get the manifest digest if repo digest is missing when getting the image hash.
Before this PR the sbom for local image (`docker.io/idanfrim/kubeclarity-cli:local`) was created with the following `metadata.component`
```
    "component": {
      "bom-ref": "87162f89d41584fc",
      "type": "container",
      "name": "docker.io/idanfrim/kubeclarity-cli",
      "version": "local"
    }
``` 

After the fix, the `metadata.component` is
```
"component": {
      "bom-ref": "87162f89d41584fc",
      "type": "container",
      "name": "docker.io/idanfrim/kubeclarity-cli",
      "version": "local",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "681d0688dfc1fe3dc8bd18009922b7fb8f899d5f99a8739f600348bbb43da34a"
        }
      ]
    }
```


## Type of Change

[X] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
