### PR TITLE
fix: use RawConfigFile() instead of ConfigFile() to get docker image config file

### DIFF
--- a/shared/pkg/utils/image_helper/image_helper.go
+++ b/shared/pkg/utils/image_helper/image_helper.go
@@ -92,7 +92,8 @@ func fetchFsCommands(img containerregistry_v1.Image) ([]*FsLayerCommand, error) 
 	}
 
 	if len(layers) != len(commands) {
-		return nil, fmt.Errorf("number of fs layers (%v) doesn't match the number of fs history entries (%v)", len(layers), len(commands))
+		log.Infof("Number of fs layers (%v) doesn't match the number of fs history entries (%v) - setting empty commands", len(layers), len(commands))
+		commands = make([]string, len(layers))
 	}
 
 	fsLayerCommands, err := createFsLayerCommands(layers, commands)

--- a/shared/pkg/utils/image_helper/image_helper.go
+++ b/shared/pkg/utils/image_helper/image_helper.go
@@ -71,9 +71,10 @@ func GetHashFromRepoDigest(repoDigests []string, imageName string) string {
 
 // fetchFsCommands retrieves information about image layers commands.
 func fetchFsCommands(img containerregistry_v1.Image) ([]*FsLayerCommand, error) {
-	conf, err := img.ConfigFile()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get config file: %v", err)
+	configFile, err := img.RawConfigFile()
+	var conf containerregistry_v1.ConfigFile
+	if err = json.Unmarshal(configFile, &conf); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config file: %v", err)
 	}
 
 	if log.IsLevelEnabled(log.DebugLevel) {
@@ -84,7 +85,7 @@ func fetchFsCommands(img containerregistry_v1.Image) ([]*FsLayerCommand, error) 
 		log.Debugf("Image config: %s", confB)
 	}
 
-	commands := getCommands(conf)
+	commands := getCommands(&conf)
 
 	layers, err := img.Layers()
 	if err != nil {
@@ -92,8 +93,7 @@ func fetchFsCommands(img containerregistry_v1.Image) ([]*FsLayerCommand, error) 
 	}
 
 	if len(layers) != len(commands) {
-		log.Infof("Number of fs layers (%v) doesn't match the number of fs history entries (%v) - setting empty commands", len(layers), len(commands))
-		commands = make([]string, len(layers))
+		return nil, fmt.Errorf("number of fs layers (%v) doesn't match the number of fs history entries (%v)", len(layers), len(commands))
 	}
 
 	fsLayerCommands, err := createFsLayerCommands(layers, commands)

--- a/shared/pkg/utils/image_helper/image_helper.go
+++ b/shared/pkg/utils/image_helper/image_helper.go
@@ -93,7 +93,8 @@ func fetchFsCommands(img containerregistry_v1.Image) ([]*FsLayerCommand, error) 
 	}
 
 	if len(layers) != len(commands) {
-		return nil, fmt.Errorf("number of fs layers (%v) doesn't match the number of fs history entries (%v)", len(layers), len(commands))
+		log.Infof("Number of fs layers (%v) doesn't match the number of fs history entries (%v) - setting empty commands", len(layers), len(commands))
+		commands = make([]string, len(layers))
 	}
 
 	fsLayerCommands, err := createFsLayerCommands(layers, commands)

--- a/shared/pkg/utils/image_helper/image_helper.go
+++ b/shared/pkg/utils/image_helper/image_helper.go
@@ -72,6 +72,10 @@ func GetHashFromRepoDigest(repoDigests []string, imageName string) string {
 // fetchFsCommands retrieves information about image layers commands.
 func fetchFsCommands(img containerregistry_v1.Image) ([]*FsLayerCommand, error) {
 	configFile, err := img.RawConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get raw config file: %v", err)
+	}
+
 	var conf containerregistry_v1.ConfigFile
 	if err = json.Unmarshal(configFile, &conf); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config file: %v", err)


### PR DESCRIPTION
## Description

Following https://github.com/openclarity/kubeclarity/pull/487, github.com/google/go-containerregistry version was update from `v0.14.0` to `v0.16.1`. 

The code [here](https://github.com/google/go-containerregistry/pull/1130/files) introduce a change in classification of empty layers in the docker history commands.

The PR here uses the RawConfigFile() since the logic maintains the old behavior. In addition we will return empty commands in the future if such mismatch happen again.

## Type of Change

[X] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
