### PR TITLE
chore: Bump golangci-lint to 1.54.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,6 +68,8 @@ linters:
     - ireturn # Allow returning with iterfaces
     - exhaustruct # Allow structures with uninitialized fields
     - gci # imports still has gci lint errors after run `gci write --skip-generated -s standard -s default -s "prefix(github.com/openclarity/kubeclarity)"`
+    - depguard # NOTE(sambetts): need discussion before enabling it
+    - tagalign # NOTE(sambetts): does not seem to provide much value
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ VERSION ?= $(shell git rev-parse HEAD)
 DOCKER_IMAGE ?= $(DOCKER_REGISTRY)/$(BINARY_NAME)
 DOCKER_TAG ?= ${VERSION}
 
+ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+BIN_DIR := $(ROOT_DIR)/bin
+
 # Dependency versions
-GOLANGCI_VERSION = 1.49.0
 LICENSEI_VERSION = 0.5.0
 
 # HELP
@@ -183,11 +185,18 @@ clean-runtime-k8s-scanner:
 clean-cis-docker-benchmark-scanner:
 	@(rm -rf cis_docker_benchmark_scanner/bin ; echo "CIS docker benchmark Scanner cleanup done" )
 
-bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
-	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint
-bin/golangci-lint-${GOLANGCI_VERSION}:
-	@mkdir -p bin
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b ./bin/ v${GOLANGCI_VERSION}
+$(BIN_DIR):
+	@mkdir -p $(BIN_DIR)
+
+GOLANGCI_BIN := $(BIN_DIR)/golangci-lint
+GOLANGCI_CONFIG := $(ROOT_DIR)/.golangci.yml
+GOLANGCI_VERSION := 1.54.2
+
+bin/golangci-lint: bin/golangci-lint-$(GOLANGCI_VERSION)
+	@ln -sf golangci-lint-$(GOLANGCI_VERSION) bin/golangci-lint
+
+bin/golangci-lint-$(GOLANGCI_VERSION): | $(BIN_DIR)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b "$(BIN_DIR)" "v$(GOLANGCI_VERSION)"
 	@mv bin/golangci-lint $@
 
 .PHONY: lint

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -36,12 +36,13 @@ const (
 	DBPortEnvVar              = "DB_PORT_NUMBER"
 	DatabaseDriver            = "DATABASE_DRIVER"
 	EnableDBInfoLogs          = "ENABLE_DB_INFO_LOGS"
-	ViewRefreshIntervalEnvVar = "DB_VIEW_REFRESH_INTERVAL"
+	ViewRefreshIntervalEnvVar = "DB_VIEW_REFRESH_INTERVAL" // nolint:gosec
 
 	FakeDataEnvVar           = "FAKE_DATA"
 	FakeRuntimeScannerEnvVar = "FAKE_RUNTIME_SCANNER"
 )
 
+// nolint:musttag
 type Config struct {
 	BackendRestPort    int
 	HealthCheckAddress string

--- a/backend/pkg/database/new_vulnerability.go
+++ b/backend/pkg/database/new_vulnerability.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	newVulnerabilityTableName  = "new_vulnerabilities"
-	newVulnerabilitiesViewName = "new_vulnerabilities_view"
+	newVulnerabilitiesViewName = "new_vulnerabilities_view" // nolint:gosec
 
 	// NOTE: when changing one of the column names change also the gorm label in NewVulnerability.
 	columnNewVulID      = "id"

--- a/backend/pkg/database/package.go
+++ b/backend/pkg/database/package.go
@@ -243,6 +243,10 @@ func (p *PackageTableHandler) GetPackagesCountPerLicense() ([]*models.PackagesCo
 			License: license,
 		})
 	}
+	err = rows.Err()
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan rows: %w", err)
+	}
 	return pkgCount, nil
 }
 
@@ -270,6 +274,10 @@ func (p *PackageTableHandler) GetPackagesCountPerLanguage() ([]*models.PackagesC
 			Count:    count,
 			Language: language,
 		})
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan rows: %w", err)
 	}
 	return pkgCount, nil
 }

--- a/cis_docker_benchmark_scanner/pkg/config/config.go
+++ b/cis_docker_benchmark_scanner/pkg/config/config.go
@@ -29,6 +29,7 @@ const (
 	Timeout = "TIMEOUT"
 )
 
+// nolint:musttag
 type Config struct {
 	ResultServiceAddress string
 	ScanUUID             string

--- a/cli/pkg/config/registry.go
+++ b/cli/pkg/config/registry.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	RegistrySkipVerifyTlS = "REGISTRY_SKIP_VERIFY_TLS"
+	RegistrySkipVerifyTlS = "REGISTRY_SKIP_VERIFY_TLS" // nolint:gosec
 	RegistryUseHTTP       = "REGISTRY_USE_HTTP"
 )
 

--- a/runtime_k8s_scanner/pkg/config/config.go
+++ b/runtime_k8s_scanner/pkg/config/config.go
@@ -28,6 +28,7 @@ const (
 	SBOMDBAddress = "SBOM_DB_ADDR"
 )
 
+// nolint:musttag
 type Config struct {
 	ResultServiceAddress string
 	SBOMDBAddress        string

--- a/sbom_db/backend/pkg/config/config.go
+++ b/sbom_db/backend/pkg/config/config.go
@@ -31,6 +31,7 @@ const (
 	FakeDataEnvVar = "FAKE_DATA"
 )
 
+// nolint:musttag
 type Config struct {
 	BackendRestPort    int
 	HealthCheckAddress string

--- a/shared/pkg/config/gomod.go
+++ b/shared/pkg/config/gomod.go
@@ -17,6 +17,6 @@ package config
 
 type GomodConfig struct{}
 
-func ConvertToGomodConfig(analyzer *Analyzer) GomodConfig {
+func ConvertToGomodConfig(_ *Analyzer) GomodConfig {
 	return GomodConfig{}
 }

--- a/shared/pkg/config/runtime_scanner.go
+++ b/shared/pkg/config/runtime_scanner.go
@@ -28,7 +28,7 @@ const (
 	ImageHashToScan       = "IMAGE_HASH_TO_SCAN"
 	ImageNameToScan       = "IMAGE_NAME_TO_SCAN"
 	ScanUUID              = "SCAN_UUID"
-	RegistrySkipVerifyTlS = "REGISTRY_SKIP_VERIFY_TLS"
+	RegistrySkipVerifyTlS = "REGISTRY_SKIP_VERIFY_TLS" // nolint:gosec
 	RegistryUseHTTP       = "REGISTRY_USE_HTTP"
 	ImagePullSecretPath   = "IMAGE_PULL_SECRET_PATH" // nolint:gosec
 )

--- a/shared/pkg/utils/cyclonedx_helper/cyclonedx_helper.go
+++ b/shared/pkg/utils/cyclonedx_helper/cyclonedx_helper.go
@@ -125,7 +125,7 @@ func GetComponentLicenses(component cdx.Component) []string {
 
 // nolint:cyclop
 func GetComponentLanguage(component cdx.Component) string {
-	// Get language from PackageURL
+	// Get language from the PackageURL.
 	// PackageURL is a mandatory field for Component, so it should exist.
 	purl, err := purl.FromString(component.PackageURL)
 	if err != nil {


### PR DESCRIPTION
## Description

This version contains a number of fixes and ensures that it works for golang 1.21+.

The depguard and tagalign linters were added since 1.52.x which are temporarily disabled as former seems to be usefull, but requires a discussion with the team before enabling it while, the latter does not seem to provide much of a value besides making the structs with struct tags a bit more readable/organized.

There are several fixes and nolint comments that were added to address lint issues identified by the new version.

## Type of Change

[ ] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[X] Other (please describe) Linter bump

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
