### PR TITLE
Update Init Container command url

### DIFF
--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             - -c
             - >
               set -x;
-              while [ $(curl -sw '%{http_code}' "http://{{ include "kubeclarity.grype-server.name" . }}:8080/healthz/ready" -o /dev/null) -ne 200 ]; do
+              while [ $(curl -sw '%{http_code}' "http://kubeclarity.{{ include "kubeclarity.grype-server.name" . }}:8080/healthz/ready" -o /dev/null) -ne 200 ]; do
                 echo waiting for grype-server to be ready; sleep 2;
               done;
           securityContext:

--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - -c
             - >
               set -x;
-              while [ $(curl -sw '%{http_code}' "http://{{ include "kubeclarity.sbom-db.name" . }}:8081/healthz/ready" -o /dev/null) -ne 200 ]; do
+              while [ $(curl -sw '%{http_code}' "http://kubeclarity.{{ include "kubeclarity.sbom-db.name" . }}:8081/healthz/ready" -o /dev/null) -ne 200 ]; do
                 echo waiting for sbom database; sleep 2;
               done;
           securityContext:


### PR DESCRIPTION
Hello
Since in the installation part, it's declared that we install the chart in the `kubeclaruty` namespace, all the services are in the `kubeclarity` namespace.
So, instead of requesting the `http://kubeclarity-kubeclarity-sbom-db:8081/healthz/ready`, we must include the namespace as well:
```shell
http://kubeclarity.kubeclarity-kubeclarity-sbom-db:8081/healthz/ready
```

---

P.S: The Kubernetes DNS structure is like this:

```shell
NAMESPACE.SVC.CLUSTER.LOCAL
```
We must use at least the `NAMESPACE.SVC` part for calling a K8s svc, so that's why we should add the `kubeclarity` namespace at the first.