### PR TITLE
fix: get local image hash from ImageID when RepoDigest is missing

### DIFF
--- a/e2e/cli_scan_test.go
+++ b/e2e/cli_scan_test.go
@@ -205,8 +205,7 @@ func TestCLIScan(t *testing.T) {
 		Assess("cli scan flow", cliScanFlowFunc).
 		Assess("cli scan flow - image with known bad metadata in cyclonedx", cliScanFlowImageWithKnownBadMetadata).
 		Assess("cli scan flow - image with no components", cliScanFlowImageWithNoComponents).
-		// TODO(idanf): uncomment the following once https://github.com/openclarity/kubeclarity/issues/498 will be resolved
-		//Assess("cli scan flow - docker archive image", cliScanFlowDockerArchiveImage).
+		Assess("cli scan flow - docker archive image", cliScanFlowDockerArchiveImage).
 		Feature()
 
 	// test features

--- a/shared/pkg/analyzer/merge.go
+++ b/shared/pkg/analyzer/merge.go
@@ -446,6 +446,16 @@ func (m *MergedResults) addSourceHash(sourceHash string) *MergedResults {
 	if sourceHash == "" {
 		return m
 	}
+
+	// We should have a single hash, need to make sure the current one (if exists) is the same and alert otherwise.
+	if m.SrcMetaData.Component.Hashes != nil && len(*m.SrcMetaData.Component.Hashes) != 0 {
+		currentSourceHash := (*m.SrcMetaData.Component.Hashes)[0].Value
+		if currentSourceHash != sourceHash {
+			log.Errorf("Conflicting hashes: new hash %q is different from existing hash %q", sourceHash, currentSourceHash)
+		}
+		return m
+	}
+
 	repoDigestHash := cdx.Hash{
 		Algorithm: cdx.HashAlgoSHA256,
 		Value:     sourceHash,

--- a/shared/pkg/analyzer/merge_test.go
+++ b/shared/pkg/analyzer/merge_test.go
@@ -385,7 +385,7 @@ func TestMergedResults_addSourceHash(t *testing.T) {
 		want   *MergedResults
 	}{
 		{
-			name: "sorceHash and hashes are empty",
+			name: "sourceHash and hashes are empty",
 			fields: fields{
 				SrcMetaData: &cdx.Metadata{
 					Component: &cdx.Component{},
@@ -431,10 +431,12 @@ func TestMergedResults_addSourceHash(t *testing.T) {
 			},
 		},
 		{
-			name: "sourceHash not empty, hashes is empty",
+			name: "sourceHash not empty, hashes is nil",
 			fields: fields{
 				SrcMetaData: &cdx.Metadata{
-					Component: &cdx.Component{},
+					Component: &cdx.Component{
+						Hashes: nil,
+					},
 				},
 			},
 			args: args{
@@ -454,13 +456,38 @@ func TestMergedResults_addSourceHash(t *testing.T) {
 			},
 		},
 		{
-			name: "sourceHash not empty, hashes has value",
+			name: "sourceHash not empty, hashes is empty",
+			fields: fields{
+				SrcMetaData: &cdx.Metadata{
+					Component: &cdx.Component{
+						Hashes: &[]cdx.Hash{},
+					},
+				},
+			},
+			args: args{
+				sourceHash: "2222",
+			},
+			want: &MergedResults{
+				SrcMetaData: &cdx.Metadata{
+					Component: &cdx.Component{
+						Hashes: &[]cdx.Hash{
+							{
+								Algorithm: cdx.HashAlgoSHA256,
+								Value:     "2222",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "sourceHash not empty, hashes are conflicting - ignoring the new one",
 			fields: fields{
 				SrcMetaData: &cdx.Metadata{
 					Component: &cdx.Component{
 						Hashes: &[]cdx.Hash{
 							{
-								Algorithm: cdx.HashAlgoSHA1,
+								Algorithm: cdx.HashAlgoSHA256,
 								Value:     "1111",
 							},
 						},
@@ -476,7 +503,7 @@ func TestMergedResults_addSourceHash(t *testing.T) {
 						Hashes: &[]cdx.Hash{
 							{
 								Algorithm: cdx.HashAlgoSHA256,
-								Value:     "2222",
+								Value:     "1111",
 							},
 						},
 					},

--- a/shared/pkg/analyzer/syft/syft.go
+++ b/shared/pkg/analyzer/syft/syft.go
@@ -126,7 +126,7 @@ func (a *Analyzer) setError(res *analyzer.Results, err error) {
 func getImageHash(sbom syft_sbom.SBOM, src string) (string, error) {
 	switch metadata := sbom.Source.Metadata.(type) {
 	case source.StereoscopeImageSourceMetadata:
-		return image_helper.GetHashFromRepoOrManifestDigest(metadata.RepoDigests, metadata.ManifestDigest, src), nil
+		return image_helper.GetHashFromRepoDigestsOrImageID(metadata.RepoDigests, metadata.ID, src), nil
 	default:
 		return "", fmt.Errorf("failed to get image hash from source metadata")
 	}

--- a/shared/pkg/analyzer/syft/syft.go
+++ b/shared/pkg/analyzer/syft/syft.go
@@ -132,7 +132,11 @@ func (a *Analyzer) setError(res *analyzer.Results, err error) {
 func getImageHash(sbom syft_sbom.SBOM, src string) (string, error) {
 	switch metadata := sbom.Source.Metadata.(type) {
 	case source.StereoscopeImageSourceMetadata:
-		return image_helper.GetHashFromRepoDigestsOrImageID(metadata.RepoDigests, metadata.ID, src), nil
+		hash, err := image_helper.GetHashFromRepoDigestsOrImageID(metadata.RepoDigests, metadata.ID, src)
+		if err != nil {
+			return "", fmt.Errorf("failed to get image hash from repo digests or image id: %w", err)
+		}
+		return hash, nil
 	default:
 		return "", fmt.Errorf("failed to get image hash from source metadata")
 	}

--- a/shared/pkg/analyzer/trivy/trivy.go
+++ b/shared/pkg/analyzer/trivy/trivy.go
@@ -168,6 +168,8 @@ func (a *Analyzer) Run(sourceType utils.SourceType, userInput string) error {
 				return
 			}
 			res.AppInfo.SourceHash = hash
+		case utils.SBOM, utils.DIR, utils.ROOTFS, utils.FILE:
+			// ignore
 		default:
 			// ignore
 		}

--- a/shared/pkg/analyzer/trivy/trivy.go
+++ b/shared/pkg/analyzer/trivy/trivy.go
@@ -206,9 +206,10 @@ func getImageHash(properties *[]cdx.Property, src string) (string, error) {
 		}
 	}
 
-	if imageID == "" && len(repoDigests) == 0 {
-		return "", fmt.Errorf("RepoDigest and ImageID properties are missing")
+	hash, err := image_helper.GetHashFromRepoDigestsOrImageID(repoDigests, imageID, src)
+	if err != nil {
+		return "", fmt.Errorf("failed to get image hash from repo digests or image id: %w", err)
 	}
 
-	return image_helper.GetHashFromRepoDigestsOrImageID(repoDigests, imageID, src), nil
+	return hash, nil
 }

--- a/shared/pkg/analyzer/trivy/trivy.go
+++ b/shared/pkg/analyzer/trivy/trivy.go
@@ -160,13 +160,16 @@ func (a *Analyzer) Run(sourceType utils.SourceType, userInput string) error {
 		// Get the RepoDigest/ImageID from image metadata and use it as
 		// SourceHash in the Result that will be added to the component
 		// hash of metadata during the merge.
-		if sourceType == utils.IMAGE {
+		switch sourceType {
+		case utils.IMAGE, utils.DOCKERARCHIVE, utils.OCIDIR, utils.OCIARCHIVE:
 			hash, err := getImageHash(bom.Metadata.Component.Properties, userInput)
 			if err != nil {
 				a.setError(res, fmt.Errorf("failed to get image hash from sbom: %w", err))
 				return
 			}
 			res.AppInfo.SourceHash = hash
+		default:
+			// ignore
 		}
 
 		a.logger.Infof("Sending successful results")

--- a/shared/pkg/analyzer/trivy/trivy_test.go
+++ b/shared/pkg/analyzer/trivy/trivy_test.go
@@ -1,0 +1,148 @@
+// Copyright © 2022 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trivy
+
+import (
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+)
+
+func Test_getImageHash(t *testing.T) {
+	type args struct {
+		properties *[]cdx.Property
+		src        string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "nil properties",
+			args: args{
+				properties: nil,
+				src:        "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "empty properties",
+			args: args{
+				properties: &[]cdx.Property{},
+				src:        "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "both RepoDigest and ImageID properties are missing",
+			args: args{
+				properties: &[]cdx.Property{
+					{
+						Name:  "name",
+						Value: "value",
+					},
+				},
+				src: "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "RepoDigest is missing and ImageID is not",
+			args: args{
+				properties: &[]cdx.Property{
+					{
+						Name:  "aquasecurity:trivy:ImageID",
+						Value: "sha256:62ed8ed20fdbb57a19639fc3a2dc8710dd66cb2364d61ec02e11cf9b35bc31dc",
+					},
+				},
+				src: "",
+			},
+			want:    "62ed8ed20fdbb57a19639fc3a2dc8710dd66cb2364d61ec02e11cf9b35bc31dc",
+			wantErr: false,
+		},
+		{
+			name: "RepoDigest is not missing and ImageID is missing",
+			args: args{
+				properties: &[]cdx.Property{
+					{
+						Name:  "aquasecurity:trivy:RepoDigest",
+						Value: "poke/debian@sha256:a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
+					},
+				},
+				src: "poke/debian:latest",
+			},
+			want:    "a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
+			wantErr: false,
+		},
+		{
+			name: "RepoDigest is not missing and ImageID is not missing - prefer RepoDigest",
+			args: args{
+				properties: &[]cdx.Property{
+					{
+						Name:  "aquasecurity:trivy:ImageID",
+						Value: "sha256:62ed8ed20fdbb57a19639fc3a2dc8710dd66cb2364d61ec02e11cf9b35bc31dc",
+					},
+					{
+						Name:  "aquasecurity:trivy:RepoDigest",
+						Value: "poke/debian@sha256:a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
+					},
+				},
+				src: "poke/debian:latest",
+			},
+			want:    "a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
+			wantErr: false,
+		},
+		{
+			name: "RepoDigest is not missing and ImageID is not missing - prefer RepoDigest and match the correct RepoDigest matching src",
+			args: args{
+				properties: &[]cdx.Property{
+					{
+						Name:  "aquasecurity:trivy:ImageID",
+						Value: "sha256:62ed8ed20fdbb57a19639fc3a2dc8710dd66cb2364d61ec02e11cf9b35bc31dc",
+					},
+					{
+						Name:  "aquasecurity:trivy:RepoDigest",
+						Value: "debian@sha256:2906804d2a64e8a13a434a1a127fe3f6a28bf7cf3696be4223b06276f32f1f2d",
+					},
+					{
+						Name:  "aquasecurity:trivy:RepoDigest",
+						Value: "poke/debian@sha256:a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
+					},
+				},
+				src: "poke/debian:latest",
+			},
+			want:    "a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getImageHash(tt.args.properties, tt.args.src)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getImageHash() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getImageHash() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/shared/pkg/scanner/grype/common.go
+++ b/shared/pkg/scanner/grype/common.go
@@ -119,7 +119,7 @@ func getSource(doc grype_models.Document, userInput, hash string) scanner.Source
 		if hash != "" {
 			break
 		}
-		hash = image_helper.GetHashFromRepoOrManifestDigest(imageMetadata.RepoDigests, imageMetadata.ManifestDigest, userInput)
+		hash = image_helper.GetHashFromRepoDigestsOrImageID(imageMetadata.RepoDigests, imageMetadata.ID, userInput)
 	case string:
 		srcName = doc.Source.Target.(string) // nolint:forcetypeassert
 	}

--- a/shared/pkg/scanner/grype/common.go
+++ b/shared/pkg/scanner/grype/common.go
@@ -119,7 +119,11 @@ func getSource(doc grype_models.Document, userInput, hash string) scanner.Source
 		if hash != "" {
 			break
 		}
-		hash = image_helper.GetHashFromRepoDigestsOrImageID(imageMetadata.RepoDigests, imageMetadata.ID, userInput)
+		if h, err := image_helper.GetHashFromRepoDigestsOrImageID(imageMetadata.RepoDigests, imageMetadata.ID, userInput); err != nil {
+			log.Warningf("Failed to get image hash from repo digests or image id: %v", err)
+		} else {
+			hash = h
+		}
 	case string:
 		srcName = doc.Source.Target.(string) // nolint:forcetypeassert
 	}

--- a/shared/pkg/scanner/grype/common_test.go
+++ b/shared/pkg/scanner/grype/common_test.go
@@ -35,12 +35,14 @@ func TestCreateResults(t *testing.T) {
 	file, err := os.ReadFile("./test_data/nginx.json")
 	assert.NilError(t, err)
 	assert.NilError(t, json.Unmarshal(file, &doc))
-	// define Target properly for image input
-	doc.Source.Target = syft_source.StereoscopeImageSourceMetadata{
-		UserInput:      "nginx",
-		ManifestDigest: "sha256:43ef2d67f4f458c2ac373ce0abf34ff6ad61616dd7cfd2880c6381d7904b6a94",
-		RepoDigests:    []string{"sha256:43ef2d67f4f458c2ac373ce0abf34ff6ad61616dd7cfd2880c6381d7904b6a94"},
-	}
+
+	// set StereoscopeImageSourceMetadata type as Target
+	marshalTarget, err := json.Marshal(doc.Source.Target)
+	assert.NilError(t, err)
+	var imageSourceMetadata syft_source.StereoscopeImageSourceMetadata
+	assert.NilError(t, json.Unmarshal(marshalTarget, &imageSourceMetadata))
+	doc.Source.Target = imageSourceMetadata
+
 	// read expected results
 	var results scanner.Results
 	file, err = os.ReadFile("./test_data/nginx.results.json")
@@ -85,6 +87,13 @@ func Test_getSource(t *testing.T) {
 	assert.NilError(t, err)
 	assert.NilError(t, json.Unmarshal(file, &doc))
 
+	// set StereoscopeImageSourceMetadata type as Target
+	marshalTarget, err := json.Marshal(doc.Source.Target)
+	assert.NilError(t, err)
+	var imageSourceMetadata syft_source.StereoscopeImageSourceMetadata
+	assert.NilError(t, json.Unmarshal(marshalTarget, &imageSourceMetadata))
+	doc.Source.Target = imageSourceMetadata
+
 	// make a copies of document
 	var sbomDoc models.Document
 	if err := copier.Copy(&sbomDoc, &doc); err != nil {
@@ -95,12 +104,6 @@ func Test_getSource(t *testing.T) {
 		t.Errorf("failed to copy document struct: %v", err)
 	}
 
-	// define Target properly for image input
-	doc.Source.Target = syft_source.StereoscopeImageSourceMetadata{
-		UserInput:      "nginx",
-		ManifestDigest: "sha256:43ef2d67f4f458c2ac373ce0abf34ff6ad61616dd7cfd2880c6381d7904b6a94",
-		RepoDigests:    []string{"sha256:43ef2d67f4f458c2ac373ce0abf34ff6ad61616dd7cfd2880c6381d7904b6a94"},
-	}
 	// empty imageMetadata for SBOM input
 	sbomDoc.Source.Target = syft_source.StereoscopeImageSourceMetadata{}
 	// string for other input
@@ -126,7 +129,7 @@ func Test_getSource(t *testing.T) {
 			want: scanner.Source{
 				Type: "image",
 				Name: "nginx",
-				Hash: "43ef2d67f4f458c2ac373ce0abf34ff6ad61616dd7cfd2880c6381d7904b6a94",
+				Hash: "644a70516a26004c97d0d85c7fe1d0c3a67ea8ab7ddf4aff193d9f301670cf36",
 			},
 		},
 		{

--- a/shared/pkg/scanner/grype/test_data/nginx.results.json
+++ b/shared/pkg/scanner/grype/test_data/nginx.results.json
@@ -11402,6 +11402,6 @@
   "source": {
     "type": "image",
     "name": "nginx",
-    "hash": "43ef2d67f4f458c2ac373ce0abf34ff6ad61616dd7cfd2880c6381d7904b6a94"
+    "hash": "644a70516a26004c97d0d85c7fe1d0c3a67ea8ab7ddf4aff193d9f301670cf36"
   }
 }

--- a/shared/pkg/scanner/trivy/scanner.go
+++ b/shared/pkg/scanner/trivy/scanner.go
@@ -363,7 +363,7 @@ func (a *Scanner) CreateResult(trivyJSON []byte, hash string) *scanner.Results {
 	a.logger.Infof("Found %d vulnerabilities", len(matches))
 
 	if string(report.ArtifactType) == "container_image" {
-		hash = image_helper.GetHashFromRepoDigest(report.Metadata.RepoDigests, report.ArtifactName)
+		hash = image_helper.GetHashFromRepoDigestsOrImageID(report.Metadata.RepoDigests, report.Metadata.ImageID, report.ArtifactName)
 	}
 
 	source := scanner.Source{

--- a/shared/pkg/scanner/trivy/scanner.go
+++ b/shared/pkg/scanner/trivy/scanner.go
@@ -281,6 +281,7 @@ func getCVSSesFromVul(vCvss trivyDBTypes.VendorCVSS) []scanner.CVSS {
 	return cvsses
 }
 
+// nolint:cyclop
 func (a *Scanner) CreateResult(trivyJSON []byte, hash string) *scanner.Results {
 	result := &scanner.Results{
 		Matches: nil, // empty results,
@@ -362,8 +363,12 @@ func (a *Scanner) CreateResult(trivyJSON []byte, hash string) *scanner.Results {
 
 	a.logger.Infof("Found %d vulnerabilities", len(matches))
 
-	if string(report.ArtifactType) == "container_image" {
-		hash = image_helper.GetHashFromRepoDigestsOrImageID(report.Metadata.RepoDigests, report.Metadata.ImageID, report.ArtifactName)
+	if hash == "" && string(report.ArtifactType) == "container_image" {
+		// If hash is missing, we will TRY to get it from RepoDigests or ImageID
+		hash, err = image_helper.GetHashFromRepoDigestsOrImageID(report.Metadata.RepoDigests, report.Metadata.ImageID, report.ArtifactName)
+		if err != nil {
+			log.Warningf("Failed to get image hash from repo digests or image id: %v", err)
+		}
 	}
 
 	source := scanner.Source{

--- a/shared/pkg/utils/image_helper/image_helper.go
+++ b/shared/pkg/utils/image_helper/image_helper.go
@@ -41,6 +41,10 @@ type FsLayerCommand struct {
 }
 
 func GetHashFromRepoDigest(repoDigests []string, imageName string) string {
+	if len(repoDigests) == 0 {
+		return ""
+	}
+
 	normalizedName, err := reference.ParseNormalizedNamed(imageName)
 	if err != nil {
 		log.Errorf("Failed to parse image name %s to normalized named: %v", imageName, err)
@@ -225,7 +229,11 @@ func GetImageLayerCommands(imageName string, sharedConf *sharedconfig.Config) ([
 	return layerCommands, nil
 }
 
-func GetHashFromRepoDigestsOrImageID(repoDigests []string, imageID string, imageName string) string {
+func GetHashFromRepoDigestsOrImageID(repoDigests []string, imageID string, imageName string) (string, error) {
+	if imageID == "" && len(repoDigests) == 0 {
+		return "", fmt.Errorf("RepoDigest and ImageID are missing")
+	}
+
 	hash := GetHashFromRepoDigest(repoDigests, imageName)
 	if hash == "" {
 		// set hash using ImageID (https://github.com/opencontainers/image-spec/blob/main/config.md#imageid) if repo digests are missing
@@ -238,5 +246,5 @@ func GetHashFromRepoDigestsOrImageID(repoDigests []string, imageID string, image
 			hash = imageID
 		}
 	}
-	return hash
+	return hash, nil
 }

--- a/shared/pkg/utils/image_helper/image_helper.go
+++ b/shared/pkg/utils/image_helper/image_helper.go
@@ -229,8 +229,11 @@ func GetHashFromRepoDigestsOrImageID(repoDigests []string, imageID string, image
 	hash := GetHashFromRepoDigest(repoDigests, imageName)
 	if hash == "" {
 		// set hash using ImageID (https://github.com/opencontainers/image-spec/blob/main/config.md#imageid) if repo digests are missing
-		if idx := strings.Index(imageID, ":"); idx != -1 {
-			hash = imageID[idx+1:]
+		// image ID is represented as a hexadecimal encoding of 256 bits, e.g., sha256:a9561eb1b190625c9adb5a9513e72c4dedafc1cb2d4c5236c9a6957ec7dfd5a9
+		// we need only the hash
+		_, h, found := strings.Cut(imageID, ":")
+		if found {
+			hash = h
 		} else {
 			hash = imageID
 		}

--- a/shared/pkg/utils/image_helper/image_helper.go
+++ b/shared/pkg/utils/image_helper/image_helper.go
@@ -225,14 +225,14 @@ func GetImageLayerCommands(imageName string, sharedConf *sharedconfig.Config) ([
 	return layerCommands, nil
 }
 
-func GetHashFromRepoOrManifestDigest(repoDigests []string, manifestDigest string, imageName string) string {
+func GetHashFromRepoDigestsOrImageID(repoDigests []string, imageID string, imageName string) string {
 	hash := GetHashFromRepoDigest(repoDigests, imageName)
 	if hash == "" {
-		// set hash using ManifestDigest if RepoDigest is missing
-		if idx := strings.Index(manifestDigest, ":"); idx != -1 {
-			hash = manifestDigest[idx+1:]
+		// set hash using ImageID (https://github.com/opencontainers/image-spec/blob/main/config.md#imageid) if repo digests are missing
+		if idx := strings.Index(imageID, ":"); idx != -1 {
+			hash = imageID[idx+1:]
 		} else {
-			hash = manifestDigest
+			hash = imageID
 		}
 	}
 	return hash

--- a/shared/pkg/utils/image_helper/image_helper_test.go
+++ b/shared/pkg/utils/image_helper/image_helper_test.go
@@ -92,9 +92,10 @@ func TestGetHashFromRepoDigestsOrImageID(t *testing.T) {
 		imageName   string
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name    string
+		args    args
+		want    string
+		wantErr bool
 	}{
 		{
 			name: "RepoDigests is not missing",
@@ -127,13 +128,14 @@ func TestGetHashFromRepoDigestsOrImageID(t *testing.T) {
 			want: "38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
 		},
 		{
-			name: "Both RepoDigests and ImageID is missing",
+			name: "Both RepoDigests and ImageID are missing",
 			args: args{
 				imageID:     "",
 				repoDigests: nil,
 				imageName:   "poke/debian:latest",
 			},
-			want: "",
+			want:    "",
+			wantErr: true,
 		},
 		{
 			name: "Both RepoDigests and ImageID not missing - prefer RepoDigests",
@@ -150,8 +152,13 @@ func TestGetHashFromRepoDigestsOrImageID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetHashFromRepoDigestsOrImageID(tt.args.repoDigests, tt.args.imageID, tt.args.imageName); got != tt.want {
-				t.Errorf("GetHashFromRepoDigestsOrImageID() = %v, want %v", got, tt.want)
+			got, err := GetHashFromRepoDigestsOrImageID(tt.args.repoDigests, tt.args.imageID, tt.args.imageName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetHashFromRepoDigestsOrImageID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetHashFromRepoDigestsOrImageID() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -206,6 +213,34 @@ func Test_stripDockerMetaFromCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := stripDockerMetaFromCommand(tt.args.command); got != tt.want {
 				t.Errorf("stripDockerMetaFromCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetHashFromRepoDigestsOrImageID1(t *testing.T) {
+	type args struct {
+		repoDigests []string
+		imageID     string
+		imageName   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetHashFromRepoDigestsOrImageID(tt.args.repoDigests, tt.args.imageID, tt.args.imageName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetHashFromRepoDigestsOrImageID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetHashFromRepoDigestsOrImageID() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/shared/pkg/utils/image_helper/image_helper_test.go
+++ b/shared/pkg/utils/image_helper/image_helper_test.go
@@ -109,7 +109,7 @@ func TestGetHashFromRepoDigestsOrImageID(t *testing.T) {
 			want: "a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
 		},
 		{
-			name: "RepoDigests is missing",
+			name: "RepoDigests is missing, ImageID is not missing",
 			args: args{
 				imageID:     "sha256:38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
 				repoDigests: nil,
@@ -118,7 +118,7 @@ func TestGetHashFromRepoDigestsOrImageID(t *testing.T) {
 			want: "38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
 		},
 		{
-			name: "RepoDigests is missing, ImageID is not missing",
+			name: "RepoDigests is missing, ImageID is not missing but with the wrong format",
 			args: args{
 				imageID:     "38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
 				repoDigests: nil,
@@ -134,6 +134,18 @@ func TestGetHashFromRepoDigestsOrImageID(t *testing.T) {
 				imageName:   "poke/debian:latest",
 			},
 			want: "",
+		},
+		{
+			name: "Both RepoDigests and ImageID not missing - prefer RepoDigests",
+			args: args{
+				imageID: "sha256:38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
+				repoDigests: []string{
+					"debian@sha256:2906804d2a64e8a13a434a1a127fe3f6a28bf7cf3696be4223b06276f32f1f2d",
+					"poke/debian@sha256:a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
+				},
+				imageName: "poke/debian:latest",
+			},
+			want: "a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
 		},
 	}
 	for _, tt := range tests {

--- a/shared/pkg/utils/image_helper/image_helper_test.go
+++ b/shared/pkg/utils/image_helper/image_helper_test.go
@@ -85,11 +85,11 @@ func TestGetRepoDigest(t *testing.T) {
 	}
 }
 
-func TestGetHashFromRepoOrManifestDigest(t *testing.T) {
+func TestGetHashFromRepoDigestsOrImageID(t *testing.T) {
 	type args struct {
-		repoDigests    []string
-		manifestDigest string
-		imageName      string
+		repoDigests []string
+		imageID     string
+		imageName   string
 	}
 	tests := []struct {
 		name string
@@ -99,7 +99,7 @@ func TestGetHashFromRepoOrManifestDigest(t *testing.T) {
 		{
 			name: "RepoDigests is not missing",
 			args: args{
-				manifestDigest: "sha256:38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
+				imageID: "sha256:38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
 				repoDigests: []string{
 					"debian@sha256:2906804d2a64e8a13a434a1a127fe3f6a28bf7cf3696be4223b06276f32f1f2d",
 					"poke/debian@sha256:a4c378901a2ba14fd331e96a49101556e91ed592d5fd68ba7405fdbf9b969e61",
@@ -111,35 +111,35 @@ func TestGetHashFromRepoOrManifestDigest(t *testing.T) {
 		{
 			name: "RepoDigests is missing",
 			args: args{
-				manifestDigest: "sha256:38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
-				repoDigests:    nil,
-				imageName:      "poke/debian:latest",
+				imageID:     "sha256:38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
+				repoDigests: nil,
+				imageName:   "poke/debian:latest",
 			},
 			want: "38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
 		},
 		{
-			name: "RepoDigests is missing, manifestDigest is missing :",
+			name: "RepoDigests is missing, ImageID is not missing",
 			args: args{
-				manifestDigest: "38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
-				repoDigests:    nil,
-				imageName:      "poke/debian:latest",
+				imageID:     "38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
+				repoDigests: nil,
+				imageName:   "poke/debian:latest",
 			},
 			want: "38f8c1d9613f3f42e7969c3b1dd5c3277e635d4576713e6453c6193e66270a6d",
 		},
 		{
-			name: "Both RepoDigests and ManifestDigest is missing",
+			name: "Both RepoDigests and ImageID is missing",
 			args: args{
-				manifestDigest: "",
-				repoDigests:    nil,
-				imageName:      "poke/debian:latest",
+				imageID:     "",
+				repoDigests: nil,
+				imageName:   "poke/debian:latest",
 			},
 			want: "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetHashFromRepoOrManifestDigest(tt.args.repoDigests, tt.args.manifestDigest, tt.args.imageName); got != tt.want {
-				t.Errorf("GetHashFromRepoOrManifestDigest() = %v, want %v", got, tt.want)
+			if got := GetHashFromRepoDigestsOrImageID(tt.args.repoDigests, tt.args.imageID, tt.args.imageName); got != tt.want {
+				t.Errorf("GetHashFromRepoDigestsOrImageID() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

The PR fixes an issue with local images sbom generation, when analyzing a local image the RepoDigests are missing so there is a need to use a common hash for the artifact, the code here takes the image ID (https://github.com/opencontainers/image-spec/blob/main/config.md/#imageid) as the identifier since it exists in both trivy and syft.

The PR fixes https://github.com/openclarity/kubeclarity/issues/498 and also update the changes done in https://github.com/openclarity/kubeclarity/pull/497

## Type of Change

[X] Bug Fix
[ ] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
