### PR TITLE
feat(helm): add extra labels for servicemonitor and ingress

### DIFF
--- a/charts/kubeclarity/templates/_helpers.tpl
+++ b/charts/kubeclarity/templates/_helpers.tpl
@@ -78,3 +78,31 @@ Sets extra Kubeclarity server Service annotations
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Sets extra labels for service monitor
+*/}}
+{{- define "kubeclarity.prometheus.serviceMonitor.labels" -}}
+  {{- if .Values.kubeclarity.prometheus.serviceMonitor.labels }}
+    {{- $tp := typeOf .Values.kubeclarity.prometheus.serviceMonitor.labels }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.kubeclarity.prometheus.serviceMonitor.labels . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.kubeclarity.prometheus.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra ingress labels
+*/}}
+{{- define "kubeclarity.ingress.labels" -}}
+  {{- if .Values.kubeclarity.ingress.labels }}
+    {{- $tp := typeOf .Values.kubeclarity.ingress.labels }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.kubeclarity.ingress.labels . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.kubeclarity.ingress.labels | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/charts/kubeclarity/templates/ingress.yaml
+++ b/charts/kubeclarity/templates/ingress.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: '{{ .Release.Namespace }}'
   labels:
     {{- include "kubeclarity.labels" . | nindent 4 }}
+  {{- template "kubeclarity.ingress.labels" . }}
   {{- template "kubeclarity.ingress.annotations" . }}
 spec:
 {{- if .Values.kubeclarity.ingress.tls }}

--- a/charts/kubeclarity/templates/servicemonitor.yaml
+++ b/charts/kubeclarity/templates/servicemonitor.yaml
@@ -8,7 +8,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "kubeclarity.labels" . | nindent 4 }}
+  {{- include "kubeclarity.labels" . | nindent 4 }}
+  {{- template "kubeclarity.prometheus.serviceMonitor.labels" . }}
 spec:
   selector:
     matchLabels:

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -60,6 +60,7 @@ kubeclarity:
       enabled: false
       interval: 30s
       annotations: {}
+      labels: {}
     refreshIntervalSeconds: 300
 
   podAnnotations: {}


### PR DESCRIPTION
## Description

Update the servicemonitor helm template to give the possibility to add extra labels which is basically required when using Prometheus since it needs a label named `release` to be able to scrap metrics.
Also updating the nginx helm template to be able to add extra labels
Tested the changes using the helm template command and all tests passed 

## Type of Change

[ ] Bug Fix
[x] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X ] All new and existing tests pass
