### PR TITLE
feat: add config for the DB SSL mode

### DIFF
--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -44,6 +44,7 @@ func main() {
 	viper.SetDefault(config.HealthCheckAddress, ":8081")
 	viper.SetDefault(config.BackendRestPort, "8080")
 	viper.SetDefault(config.DatabaseDriver, database.DBDriverTypePostgres)
+	viper.SetDefault(config.DBSSLMode, "disable")
 	viper.SetDefault(config.ViewRefreshIntervalEnvVar, database.DefaultViewRefreshIntervalSecond)
 	viper.AutomaticEnv()
 	app := cli.NewApp()

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -44,7 +44,7 @@ func main() {
 	viper.SetDefault(config.HealthCheckAddress, ":8081")
 	viper.SetDefault(config.BackendRestPort, "8080")
 	viper.SetDefault(config.DatabaseDriver, database.DBDriverTypePostgres)
-	viper.SetDefault(config.DBSSLMode, "disable")
+	viper.SetDefault(config.DBSSLModeEnvVar, "disable")
 	viper.SetDefault(config.ViewRefreshIntervalEnvVar, database.DefaultViewRefreshIntervalSecond)
 	viper.AutomaticEnv()
 	app := cli.NewApp()

--- a/backend/pkg/backend/backend.go
+++ b/backend/pkg/backend/backend.go
@@ -58,6 +58,7 @@ func createDatabaseConfig(config *_config.Config) *_database.DBConfig {
 		DBHost:                    config.DBHost,
 		DBPort:                    config.DBPort,
 		DBName:                    config.DBName,
+		DBSSLMode:                 config.DBSSLMode,
 		ViewRefreshIntervalSecond: config.ViewRefreshIntervalSecond,
 	}
 }

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -34,6 +34,7 @@ const (
 	DBPasswordEnvVar          = "DB_PASS"
 	DBHostEnvVar              = "DB_HOST"
 	DBPortEnvVar              = "DB_PORT_NUMBER"
+	DBSSLModeEnvVar           = "DB_SSL_MODE"
 	DatabaseDriver            = "DATABASE_DRIVER"
 	EnableDBInfoLogs          = "ENABLE_DB_INFO_LOGS"
 	ViewRefreshIntervalEnvVar = "DB_VIEW_REFRESH_INTERVAL" // nolint:gosec
@@ -57,6 +58,7 @@ type Config struct {
 	DBPassword                string
 	DBHost                    string
 	DBPort                    string
+	DBSSLMode                 string
 	EnableDBInfoLogs          bool
 	EnableFakeData            bool
 	EnableFakeRuntimeScanner  bool
@@ -77,6 +79,7 @@ func LoadConfig() (*Config, error) {
 	config.DBHost = viper.GetString(DBHostEnvVar)
 	config.DBPort = viper.GetString(DBPortEnvVar)
 	config.DBName = viper.GetString(DBNameEnvVar)
+	config.DBSSLMode = viper.GetString(DBSSLModeEnvVar)
 	config.ViewRefreshIntervalSecond = viper.GetInt(ViewRefreshIntervalEnvVar)
 	config.EnableDBInfoLogs = viper.GetBool(EnableDBInfoLogs)
 

--- a/backend/pkg/database/database.go
+++ b/backend/pkg/database/database.go
@@ -387,6 +387,7 @@ type DBConfig struct {
 	DBHost                    string
 	DBPort                    string
 	DBName                    string
+	DBSSLMode                 string
 	ViewRefreshIntervalSecond int
 }
 
@@ -661,8 +662,8 @@ func dropViewIfExists(db *gorm.DB, viewName, dbDriver string) {
 }
 
 func initPostgres(config *DBConfig, dbLogger logger.Interface) *gorm.DB {
-	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=disable TimeZone=UTC",
-		config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.DBPort)
+	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=%s TimeZone=UTC",
+		config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.DBPort, config.DBSSLMode)
 
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		Logger: dbLogger,

--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -16,7 +16,7 @@
   {{- $dbPort = index .Values "kubeclarity-postgresql-external" "auth" "port" -}}
   {{- $dbUser = index .Values "kubeclarity-postgresql-external" "auth" "username" -}}
   {{- $dbName = index .Values "kubeclarity-postgresql-external" "auth" "database" -}}
-  {{- $dbSSLMode = index .Values "kubeclarity-postgresql" "auth" "sslMode" -}}
+  {{- $dbSSLMode = index .Values "kubeclarity-postgresql-external" "auth" "sslMode" -}}
 {{ end }}
 {{- $affinity := (coalesce .Values.kubeclarity.affinity .Values.global.affinity) -}}
 {{- $nodeSelector := (coalesce .Values.kubeclarity.nodeSelector .Values.global.nodeSelector) -}}

--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -9,14 +9,14 @@
 {{- $dbPort := index .Values "kubeclarity-postgresql" "service" "ports" "postgresql" -}}
 {{- $dbUser := index .Values "kubeclarity-postgresql" "auth" "username" -}}
 {{- $dbName := index .Values "kubeclarity-postgresql" "auth" "database" -}}
-{{- $dbSslMode := index .Values "kubeclarity-postgresql" "auth" "sslMode" -}}
+{{- $dbSSLMode := index .Values "kubeclarity-postgresql" "auth" "sslMode" -}}
 {{ if index .Values "kubeclarity-postgresql-external" "enabled" }}
   {{- $secretName = index .Values "kubeclarity-postgresql-external" "auth" "existingSecret" -}}
   {{- $dbHost = index .Values "kubeclarity-postgresql-external" "auth" "host" -}}
   {{- $dbPort = index .Values "kubeclarity-postgresql-external" "auth" "port" -}}
   {{- $dbUser = index .Values "kubeclarity-postgresql-external" "auth" "username" -}}
   {{- $dbName = index .Values "kubeclarity-postgresql-external" "auth" "database" -}}
-  {{- $dbSslMode = index .Values "kubeclarity-postgresql" "auth" "sslMode" -}}
+  {{- $dbSSLMode = index .Values "kubeclarity-postgresql" "auth" "sslMode" -}}
 {{ end }}
 {{- $affinity := (coalesce .Values.kubeclarity.affinity .Values.global.affinity) -}}
 {{- $nodeSelector := (coalesce .Values.kubeclarity.nodeSelector .Values.global.nodeSelector) -}}

--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -9,12 +9,14 @@
 {{- $dbPort := index .Values "kubeclarity-postgresql" "service" "ports" "postgresql" -}}
 {{- $dbUser := index .Values "kubeclarity-postgresql" "auth" "username" -}}
 {{- $dbName := index .Values "kubeclarity-postgresql" "auth" "database" -}}
+{{- $dbSslMode := index .Values "kubeclarity-postgresql" "auth" "sslMode" -}}
 {{ if index .Values "kubeclarity-postgresql-external" "enabled" }}
   {{- $secretName = index .Values "kubeclarity-postgresql-external" "auth" "existingSecret" -}}
   {{- $dbHost = index .Values "kubeclarity-postgresql-external" "auth" "host" -}}
   {{- $dbPort = index .Values "kubeclarity-postgresql-external" "auth" "port" -}}
   {{- $dbUser = index .Values "kubeclarity-postgresql-external" "auth" "username" -}}
   {{- $dbName = index .Values "kubeclarity-postgresql-external" "auth" "database" -}}
+  {{- $dbSslMode = index .Values "kubeclarity-postgresql" "auth" "sslMode" -}}
 {{ end }}
 {{- $affinity := (coalesce .Values.kubeclarity.affinity .Values.global.affinity) -}}
 {{- $nodeSelector := (coalesce .Values.kubeclarity.nodeSelector .Values.global.nodeSelector) -}}
@@ -143,6 +145,8 @@ spec:
               value: {{ $dbPort | quote }}
             - name: DB_USER
               value: {{ $dbUser | quote }}
+            - name: DB_SSL_MODE
+              value: {{ $dbSslMode | quote }}
             - name: DB_PASS
               valueFrom:
                 secretKeyRef:

--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
             - name: DB_USER
               value: {{ $dbUser | quote }}
             - name: DB_SSL_MODE
-              value: {{ $dbSslMode | quote }}
+              value: {{ $dbSSLMode | quote }}
             - name: DB_PASS
               valueFrom:
                 secretKeyRef:

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -399,6 +399,7 @@ kubeclarity-postgresql:
     existingSecret: kubeclarity-postgresql-secret
     username: postgres
     database: kubeclarity
+    sslMode: disable
 
   service:
     ports:
@@ -448,6 +449,7 @@ kubeclarity-postgresql-external:
     host: pgsql.hostname  # replace this to reach your PostgreSQL instance
     port: 5432
     database: kubeclarity
+    sslMode: disable
 
 # PostgreSQL connection information
 kubeclarity-postgresql-secret:


### PR DESCRIPTION
## Description

This adds a configuration option to set the sslMode when connecting to the backend database. It was previously hard-coded to "disable" in the connection string.

## Type of Change

[ ] Bug Fix
[x] New Feature
[ ] Breaking Change
[ ] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
