### PR TITLE
fix(helm): Capitalize `capabilities.drop[]` due to PSS

### DIFF
--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             capabilities:
               drop:
-                - all
+                - ALL
             runAsNonRoot: true
           {{- if not .Values.global.openShiftRestricted }}
             runAsUser: 1001
@@ -78,7 +78,7 @@ spec:
           securityContext:
             capabilities:
               drop:
-                - all
+                - ALL
             runAsNonRoot: true
           {{- if not .Values.global.openShiftRestricted }}
             runAsUser: 1001
@@ -102,7 +102,7 @@ spec:
           securityContext:
             capabilities:
               drop:
-                - all
+                - ALL
             runAsNonRoot: true
           {{- if not .Values.global.openShiftRestricted }}
             runAsUser: 1001
@@ -189,7 +189,7 @@ spec:
           securityContext:
             capabilities:
               drop:
-                - all
+                - ALL
             runAsNonRoot: true
             {{- if not .Values.global.openShiftRestricted }}
             runAsGroup: 1000

--- a/charts/kubeclarity/templates/grype_server/deployment.yaml
+++ b/charts/kubeclarity/templates/grype_server/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           securityContext:
             capabilities:
               drop:
-                - all
+                - ALL
             runAsNonRoot: true
             {{- if not .Values.global.openShiftRestricted }}
             runAsGroup: 1000

--- a/charts/kubeclarity/templates/sbom_db/deployment.yaml
+++ b/charts/kubeclarity/templates/sbom_db/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           securityContext:
             capabilities:
               drop:
-                - all
+                - ALL
             runAsNonRoot: true
             {{- if not .Values.global.openShiftRestricted }}
             runAsGroup: 1000

--- a/charts/kubeclarity/templates/scanner-template-configmap.yaml
+++ b/charts/kubeclarity/templates/scanner-template-configmap.yaml
@@ -133,7 +133,7 @@ data:
             securityContext:
               capabilities:
                 drop:
-                - all
+                - ALL
               runAsNonRoot: true
               {{- if not .Values.global.openShiftRestricted }}
               runAsGroup: 1001
@@ -182,7 +182,7 @@ data:
             securityContext:
               capabilities:
                 drop:
-                  - all
+                  - ALL
               runAsNonRoot: true
               {{- if not .Values.global.openShiftRestricted }}
               runAsGroup: 1001

--- a/runtime_scan/pkg/config/scanner_template.go
+++ b/runtime_scan/pkg/config/scanner_template.go
@@ -50,7 +50,7 @@ spec:
       securityContext:
         capabilities:
           drop:
-          - all
+          - ALL
         runAsNonRoot: true
         runAsGroup: 1001
         runAsUser: 1001

--- a/runtime_scan/pkg/scanner/job_managment_test.go
+++ b/runtime_scan/pkg/scanner/job_managment_test.go
@@ -718,7 +718,7 @@ spec:
         securityContext:
           capabilities:
             drop:
-            - all
+            - ALL
           runAsNonRoot: true
           runAsGroup: 1001
           runAsUser: 1001
@@ -766,7 +766,7 @@ spec:
         securityContext:
           capabilities:
             drop:
-            - all
+            - ALL
           runAsNonRoot: true
           runAsGroup: 1001
           runAsUser: 1001
@@ -822,7 +822,7 @@ spec:
         securityContext:
           capabilities:
             drop:
-            - all
+            - ALL
           runAsNonRoot: true
           runAsGroup: 1001
           runAsUser: 1001
@@ -878,7 +878,7 @@ spec:
         securityContext:
           capabilities:
             drop:
-            - all
+            - ALL
           runAsNonRoot: true
           runAsGroup: 1001
           runAsUser: 1001
@@ -945,7 +945,7 @@ spec:
         securityContext:
           capabilities:
             drop:
-            - all
+            - ALL
           runAsNonRoot: true
           runAsGroup: 1001
           runAsUser: 1001
@@ -1003,7 +1003,7 @@ spec:
         securityContext:
           capabilities:
             drop:
-            - all
+            - ALL
           runAsNonRoot: true
           runAsGroup: 1001
           runAsUser: 1001


### PR DESCRIPTION
## Description

The [pod security standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/) (PSS) level `restricted` enforces to have
```yaml
securityContext:
  capabilities:
    drop: [ALL]
```
set for all containers. At least with Kyverno, this check is case sensitive, so our Kubeclarity pods are rejected. Until now, this is set to lower case `all` in the Helm chart templates. This change capitalizes every `all` to `ALL` to be pedantically conformant with PSS.

I guess it would be more flexible to have these settings as defaults in the chart values, instead of hard-coding. If you wish, I am happy to change that, too.

## Type of Change

- [x] Bug Fix
