### PR TITLE
Revert "build(deps): bump golang from 1.21.3-alpine to 1.21.5-alpine (#568)"

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -7,7 +7,7 @@ COPY ui .
 RUN npm i
 RUN npm run build
 
-FROM golang:1.21.5-alpine AS builder
+FROM golang:1.21.3-alpine AS builder
 
 RUN apk add --update --no-cache gcc g++ git ca-certificates build-base
 

--- a/Dockerfile.cis_docker_benchmark_scanner
+++ b/Dockerfile.cis_docker_benchmark_scanner
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.2
-FROM golang:1.21.5-alpine AS builder
+FROM golang:1.21.3-alpine AS builder
 
 RUN apk add --update --no-cache gcc g++ git ca-certificates build-base
 

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.2
-FROM golang:1.21.5-alpine AS builder
+FROM golang:1.21.3-alpine AS builder
 
 RUN apk add --update --no-cache gcc g++ git ca-certificates build-base
 

--- a/Dockerfile.runtime_k8s_scanner
+++ b/Dockerfile.runtime_k8s_scanner
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.2
-FROM golang:1.21.5-alpine AS builder
+FROM golang:1.21.3-alpine AS builder
 
 RUN apk add --update --no-cache gcc g++ git ca-certificates build-base
 

--- a/Dockerfile.sbom_db
+++ b/Dockerfile.sbom_db
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.2
-FROM golang:1.21.5-alpine AS builder
+FROM golang:1.21.3-alpine AS builder
 
 RUN apk add --update --no-cache gcc g++ git ca-certificates build-base
 


### PR DESCRIPTION
This reverts commit 6f29bd6c06e2d0dbf1cbb35bd1e7a0a6df312107.

This fixes the build issues found in the `kubeclarity` and `sbom-db` images.

