### PR TITLE
Allow configurable securityContext for all involved components

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,10 @@ KubeClarity vulnerability scanner integrates with the following scanners:
    or for OpenShift Restricted SCC compatible install:
 
    ```shell
-   helm install --values values.yaml --create-namespace kubeclarity kubeclarity/kubeclarity -n kubeclarity --set global.openShiftRestricted=true \
+   helm install --values values.yaml --create-namespace kubeclarity kubeclarity/kubeclarity -n kubeclarity \
+     --set global.podSecurityContext.fsGroup=null --set global.containerSecurityContext.ruAsGroup=null --set global.containerSecurityContext.ruAsUser=null \
+     --set kubeclarity-grype-server.podSecurityContext.fsGroup=null --set kubeclarity-grype-server.containerSecurityContext.ruAsGroup=null --set kubeclarity-grype-server.containerSecurityContext.ruAsUser=null \
+     --set kubeclarity-sbom-db.podSecurityContext.fsGroup=null --set kubeclarity-sbom-db.containerSecurityContext.ruAsGroup=null --set kubeclarity-sbom-db.containerSecurityContext.ruAsUser=null \
      --set kubeclarity-postgresql.securityContext.enabled=false --set kubeclarity-postgresql.containerSecurityContext.enabled=false \
      --set kubeclarity-postgresql.volumePermissions.enabled=true --set kubeclarity-postgresql.volumePermissions.securityContext.runAsUser="auto" \
      --set kubeclarity-postgresql.shmVolume.chmod.enabled=false

--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -15,6 +15,8 @@
 {{ end }}
 {{- $affinity := (coalesce .Values.kubeclarity.affinity .Values.global.affinity) -}}
 {{- $nodeSelector := (coalesce .Values.kubeclarity.nodeSelector .Values.global.nodeSelector) -}}
+{{- $podSecurityContext := (coalesce .Values.kubeclarity.podSecurityContext .Values.global.podSecurityContext) -}}
+{{- $containerSecurityContext := (coalesce .Values.kubeclarity.containerSecurityContext .Values.global.containerSecurityContext) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,6 +44,8 @@ spec:
       {{- if $nodeSelector }}
       nodeSelector: {{- toYaml $nodeSelector | nindent 8 }}
       {{- end }}
+      securityContext:
+      {{- toYaml $podSecurityContext | nindent 8 }}
       initContainers:
         - name: '{{ include "kubeclarity.name" . }}-wait-for-pg-db'
           image: {{ index .Values "kubeclarity-postgresql" "image" "registry" }}/{{ index .Values "kubeclarity-postgresql" "image" "repository" }}:{{ index .Values "kubeclarity-postgresql" "image" "tag" }}
@@ -69,16 +73,7 @@ spec:
                   name: {{ $secretName }}
                   key: {{ $usernameKey }}
           securityContext:
-            capabilities:
-              drop:
-                - ALL
-            runAsNonRoot: true
-          {{- if not .Values.global.openShiftRestricted }}
-            runAsUser: 1001
-          {{- end }}
-            privileged: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+          {{- toYaml $containerSecurityContext | nindent 12 }}
           resources:
 {{- toYaml .Values.kubeclarity.initContainers.resources | nindent 12 }}
         - name: '{{ include "kubeclarity.name" . }}-wait-for-sbom-db'
@@ -92,16 +87,7 @@ spec:
                 echo waiting for sbom database; sleep 2;
               done;
           securityContext:
-            capabilities:
-              drop:
-                - ALL
-            runAsNonRoot: true
-          {{- if not .Values.global.openShiftRestricted }}
-            runAsUser: 1001
-          {{- end }}
-            privileged: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+          {{- toYaml $containerSecurityContext | nindent 12 }}
           resources:
 {{- toYaml .Values.kubeclarity.initContainers.resources | nindent 12 }}
 {{- if index .Values "kubeclarity-grype-server" "enabled" }}
@@ -116,16 +102,7 @@ spec:
                 echo waiting for grype-server to be ready; sleep 2;
               done;
           securityContext:
-            capabilities:
-              drop:
-                - ALL
-            runAsNonRoot: true
-          {{- if not .Values.global.openShiftRestricted }}
-            runAsUser: 1001
-          {{- end }}
-            privileged: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+          {{- toYaml $containerSecurityContext | nindent 12 }}
           resources:
 {{- toYaml .Values.kubeclarity.initContainers.resources | nindent 12 }}
 {{- end}}
@@ -218,16 +195,6 @@ spec:
             failureThreshold: 5
             timeoutSeconds: 10
           securityContext:
-            capabilities:
-              drop:
-                - ALL
-            runAsNonRoot: true
-            {{- if not .Values.global.openShiftRestricted }}
-            runAsGroup: 1000
-            runAsUser: 1000
-            {{- end }}
-            privileged: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+          {{- toYaml $containerSecurityContext | nindent 12 }}
           resources:
 {{- toYaml .Values.kubeclarity.resources | nindent 12 }}

--- a/charts/kubeclarity/templates/grype_server/deployment.yaml
+++ b/charts/kubeclarity/templates/grype_server/deployment.yaml
@@ -1,6 +1,8 @@
 {{- if index .Values "kubeclarity-grype-server" "enabled" }}
 {{- $affinity := (coalesce (index .Values "kubeclarity-grype-server" "affinity") .Values.global.affinity) -}}
 {{- $nodeSelector := (coalesce (index .Values "kubeclarity-grype-server" "nodeSelector") .Values.global.nodeSelector) -}}
+{{- $podSecurityContext := (coalesce (index .Values "kubeclarity-grype-server" "podSecurityContext") .Values.global.podSecurityContext) -}}
+{{- $containerSecurityContext := (coalesce (index .Values "kubeclarity-grype-server" "containerSecurityContext") .Values.global.containerSecurityContext) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,10 +24,8 @@ spec:
       volumes:
         - name: tmp-volume
           emptyDir: {}
-      {{- if not .Values.global.openShiftRestricted }}
       securityContext:
-        fsGroup: 1000
-      {{- end }}
+      {{- toYaml $podSecurityContext | nindent 8 }}
       {{- if $affinity }}
       affinity: {{- toYaml $affinity | nindent 8 }}
       {{- end }}
@@ -67,17 +67,7 @@ spec:
             failureThreshold: 5
             timeoutSeconds: 10
           securityContext:
-            capabilities:
-              drop:
-                - ALL
-            runAsNonRoot: true
-            {{- if not .Values.global.openShiftRestricted }}
-            runAsGroup: 1000
-            runAsUser: 1000
-            {{- end }}
-            privileged: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+          {{- toYaml $containerSecurityContext | nindent 12 }}
           resources:
 {{- toYaml (index .Values "kubeclarity-grype-server" "resources") | nindent 12 }}
           volumeMounts:

--- a/charts/kubeclarity/templates/sbom_db/deployment.yaml
+++ b/charts/kubeclarity/templates/sbom_db/deployment.yaml
@@ -1,5 +1,7 @@
 {{- $affinity := (coalesce (index .Values "kubeclarity-sbom-db" "affinity") .Values.global.affinity) -}}
 {{- $nodeSelector := (coalesce (index .Values "kubeclarity-sbom-db" "nodeSelector") .Values.global.nodeSelector) -}}
+{{- $podSecurityContext := (coalesce (index .Values "kubeclarity-sbom-db" "podSecurityContext") .Values.global.podSecurityContext) -}}
+{{- $containerSecurityContext := (coalesce (index .Values "kubeclarity-sbom-db" "containerSecurityContext") .Values.global.containerSecurityContext) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,10 +23,8 @@ spec:
       volumes:
         - name: tmp-volume
           emptyDir: {}
-      {{- if not .Values.global.openShiftRestricted }}
       securityContext:
-        fsGroup: 1000
-      {{- end }}
+      {{- toYaml $podSecurityContext | nindent 8 }}
       {{- if $affinity }}
       affinity: {{- toYaml $affinity | nindent 8 }}
       {{- end }}
@@ -60,19 +60,9 @@ spec:
             failureThreshold: 5
             timeoutSeconds: 10
           securityContext:
-            capabilities:
-              drop:
-                - ALL
-            runAsNonRoot: true
-            {{- if not .Values.global.openShiftRestricted }}
-            runAsGroup: 1000
-            runAsUser: 1000
-            {{- end }}
-            privileged: false
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+          {{- toYaml $containerSecurityContext | nindent 12 }}
           resources:
-{{- toYaml (index .Values "kubeclarity-sbom-db" "resources") | nindent 12 }}
+          {{- toYaml (index .Values "kubeclarity-sbom-db" "resources") | nindent 12 }}
           volumeMounts:
             - mountPath: /tmp
               name: tmp-volume

--- a/charts/kubeclarity/templates/scanner-template-configmap.yaml
+++ b/charts/kubeclarity/templates/scanner-template-configmap.yaml
@@ -7,6 +7,7 @@
 {{- end -}}
 {{- $affinity := (coalesce (index .Values "kubeclarity-runtime-scan" "affinity") .Values.global.affinity) -}}
 {{- $nodeSelector := (coalesce (index .Values "kubeclarity-runtime-scan" "nodeSelector") .Values.global.nodeSelector) -}}
+{{- $podSecurityContext := (coalesce (index .Values "kubeclarity-runtime-scan" "podSecurityContext") .Values.global.podSecurityContext) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -44,10 +45,8 @@ data:
           volumes:
           - name: tmp-volume
             emptyDir: {}
-          {{- if not .Values.global.openShiftRestricted }}
           securityContext:
-            fsGroup: 1001
-          {{- end }}
+          {{- toYaml $podSecurityContext | nindent 12 }}
           containers:
           - name: vulnerability-scanner
             {{- if index .Values "kubeclarity-runtime-scan" "vulnerability-scanner" "docker" "imageName" }}
@@ -131,17 +130,7 @@ data:
               value: {{ join "," $noproxy }}
 {{- end}}
             securityContext:
-              capabilities:
-                drop:
-                - ALL
-              runAsNonRoot: true
-              {{- if not .Values.global.openShiftRestricted }}
-              runAsGroup: 1001
-              runAsUser: 1001
-              {{- end }}
-              privileged: false
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
+            {{- toYaml (coalesce (index .Values "kubeclarity-runtime-scan" "vulnerability-scanner" "containerSecurityContext") .Values.global.containerSecurityContext) | nindent 14 }}
             resources:
 {{- toYaml (index .Values "kubeclarity-runtime-scan" "vulnerability-scanner" "resources") | nindent 14 }}
           - name: cis-docker-benchmark-scanner
@@ -180,16 +169,6 @@ data:
               value: {{ join "," $noproxy }}
 {{- end}}
             securityContext:
-              capabilities:
-                drop:
-                  - ALL
-              runAsNonRoot: true
-              {{- if not .Values.global.openShiftRestricted }}
-              runAsGroup: 1001
-              runAsUser: 1001
-              {{- end }}
-              privileged: false
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
+            {{- toYaml (coalesce (index .Values "kubeclarity-runtime-scan" "cis-docker-benchmark-scanner" "containerSecurityContext") .Values.global.containerSecurityContext) | nindent 14 }}
             resources:
 {{- toYaml (index .Values "kubeclarity-runtime-scan" "cis-docker-benchmark-scanner" "resources") | nindent 14 }}

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -15,16 +15,27 @@ global:
     tag: "latest"
     imagePullPolicy: Always
 
-  ## Is this being installed under OpenShift restricted SCC?
-  ## NOTE: You also need to set the PostgreSQL section correctly if using the OpenShift restricted SCC
-  openShiftRestricted: false
-
   ## Affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # affinity: {}
   nodeSelector:
-    kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
+    #kubernetes.io/os: linux
+    #kubernetes.io/arch: amd64
+
+  podSecurityContext:
+    fsGroup: 1001
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    # set to nil in order to be openshift scc compliant
+    runAsUser: 1001
+    runAsGroup: 1001
 
 ## End of Global Values
 #######################################################################################
@@ -64,6 +75,13 @@ kubeclarity:
     refreshIntervalSeconds: 300
 
   podAnnotations: {}
+
+  podSecurityContext: {}
+  
+  containerSecurityContext: {}
+
+  ## Overrides global.containerSecurityContext
+  # containerSecurityContext: {}
 
   service:
     type: ClusterIP
@@ -145,8 +163,10 @@ kubeclarity-runtime-scan:
   # 1. The scanner job must run in the pod namespace to fetch image pull secrets, OR
   # 2. The scanner job must run in the release namespace to fetch service credentials (more info in https://github.com/openclarity/kubeclarity#private-registries-support-for-k8s-runtime-scan)
   namespace: ""
-
-  ## Scanner pods tolerations.
+  
+  ## Overrides global.podSecurityContext
+  # podSecurityContext: {}
+  
   # tolerations:
   # - key: key1
   #   operator: Exists
@@ -188,6 +208,9 @@ kubeclarity-runtime-scan:
       limits:
         memory: "1000Mi"
         cpu: "1000m"
+    
+    ## Overrides global.containerSecurityContext
+    # containerSecurityContext: {}
 
   vulnerability-scanner:
     ## Docker Image values.
@@ -206,6 +229,11 @@ kubeclarity-runtime-scan:
       limits:
         memory: "1000Mi"
         cpu: "1000m"
+
+    ## Overrides global.containerSecurityContext
+    # containerSecurityContext: {}
+
+  ## Scanner pods tolerations.
 
     ## Analyzer config.
     analyzer:
@@ -280,7 +308,23 @@ kubeclarity-grype-server:
     limits:
       cpu: "1000m"
       memory: "1G"
+    
+  ## Overrides global.podSecurityContext
+  podSecurityContext:
+    fsGroup: 1000
 
+  ## Overrides global.containerSecurityContext
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    
   ## Overrides global.affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # affinity: {}
@@ -358,6 +402,22 @@ kubeclarity-sbom-db:
     limits:
       memory: "1Gi"
       cpu: "200m"
+  
+  ## Overrides global.podSecurityContext
+  podSecurityContext:
+    fsGroup: 1000
+
+  ## Overrides global.containerSecurityContext
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
 
   ## Overrides global.affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
## Description
This PR allows users of the Chart to declare custom security contexts for pods and containers. As a default, the hardcoded values from before are still delivered in the values.

By doing that, one could for example add a seccomp profile easily and the chart can be deployed to more restricted environments again.

In favor of a more readable and comprehensive solution, I dropped the `global.openShiftRestricted` flag. For non-open shift users, behavior is as before. OpenShift users need to overwrite the UID and GID in the values files now directly. The corresponding install command for open shift cluster is adapted to the new flags.

Additionally, I changed the used UID for kubeclarity image - again, for the sake of simplicity of the chart. As there is no USER directive in the Dockerfile or any other UID-bound commands (like mkdir / chmod / ... ) it should be just fine. I started it in local kind cluster and could not find any issue.

Resolves #626 and #599 
## Type of Change

[ ] Bug Fix
[X] New Feature
[ ] Breaking Change
[X] Refactor
[ ] Documentation
[ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
