### PR TITLE
Helm: Support tolerations for kubeclarity / sbom / grype

### DIFF
--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -14,6 +14,7 @@
   {{- $secretName = index .Values "kubeclarity-postgresql-external" "auth" "existingSecret" -}}
 {{ end }}
 {{- $affinity := (coalesce .Values.kubeclarity.affinity .Values.global.affinity) -}}
+{{- $tolerations := (coalesce (index .Values "kubeclarity-grype-server" "tolerations") .Values.global.tolerations) -}}
 {{- $nodeSelector := (coalesce .Values.kubeclarity.nodeSelector .Values.global.nodeSelector) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -38,6 +39,9 @@ spec:
       serviceAccountName: {{ include "kubeclarity.name" . }}
       {{- if $affinity }}
       affinity: {{- toYaml $affinity | nindent 8 }}
+      {{- end }}
+      {{- if $tolerations }}
+      tolerations: {{- toYaml $tolerations | nindent 8 }}
       {{- end }}
       {{- if $nodeSelector }}
       nodeSelector: {{- toYaml $nodeSelector | nindent 8 }}

--- a/charts/kubeclarity/templates/deployment.yaml
+++ b/charts/kubeclarity/templates/deployment.yaml
@@ -14,7 +14,7 @@
   {{- $secretName = index .Values "kubeclarity-postgresql-external" "auth" "existingSecret" -}}
 {{ end }}
 {{- $affinity := (coalesce .Values.kubeclarity.affinity .Values.global.affinity) -}}
-{{- $tolerations := (coalesce (index .Values "kubeclarity-grype-server" "tolerations") .Values.global.tolerations) -}}
+{{- $tolerations := (coalesce .Values.kubeclarity.tolerations .Values.global.tolerations) -}}
 {{- $nodeSelector := (coalesce .Values.kubeclarity.nodeSelector .Values.global.nodeSelector) -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/kubeclarity/templates/grype_server/deployment.yaml
+++ b/charts/kubeclarity/templates/grype_server/deployment.yaml
@@ -1,5 +1,6 @@
 {{- if index .Values "kubeclarity-grype-server" "enabled" }}
 {{- $affinity := (coalesce (index .Values "kubeclarity-grype-server" "affinity") .Values.global.affinity) -}}
+{{- $tolerations := (coalesce (index .Values "kubeclarity-grype-server" "tolerations") .Values.global.tolerations) -}}
 {{- $nodeSelector := (coalesce (index .Values "kubeclarity-grype-server" "nodeSelector") .Values.global.nodeSelector) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -28,6 +29,9 @@ spec:
       {{- end }}
       {{- if $affinity }}
       affinity: {{- toYaml $affinity | nindent 8 }}
+      {{- end }}
+      {{- if $tolerations }}
+      tolerations: {{- toYaml $tolerations | nindent 8 }}
       {{- end }}
       {{- if $nodeSelector }}
       nodeSelector: {{- toYaml $nodeSelector | nindent 8 }}

--- a/charts/kubeclarity/templates/sbom_db/deployment.yaml
+++ b/charts/kubeclarity/templates/sbom_db/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $affinity := (coalesce (index .Values "kubeclarity-sbom-db" "affinity") .Values.global.affinity) -}}
-{{- $tolerations := (coalesce (index .Values "kubeclarity-grype-server" "tolerations") .Values.global.tolerations) -}}
+{{- $tolerations := (coalesce (index .Values "kubeclarity-sbom-db" "tolerations") .Values.global.tolerations) -}}
 {{- $nodeSelector := (coalesce (index .Values "kubeclarity-sbom-db" "nodeSelector") .Values.global.nodeSelector) -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/kubeclarity/templates/sbom_db/deployment.yaml
+++ b/charts/kubeclarity/templates/sbom_db/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $affinity := (coalesce (index .Values "kubeclarity-sbom-db" "affinity") .Values.global.affinity) -}}
+{{- $tolerations := (coalesce (index .Values "kubeclarity-grype-server" "tolerations") .Values.global.tolerations) -}}
 {{- $nodeSelector := (coalesce (index .Values "kubeclarity-sbom-db" "nodeSelector") .Values.global.nodeSelector) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -27,6 +28,9 @@ spec:
       {{- end }}
       {{- if $affinity }}
       affinity: {{- toYaml $affinity | nindent 8 }}
+      {{- end }}
+      {{- if $tolerations }}
+      tolerations: {{- toYaml $tolerations | nindent 8 }}
       {{- end }}
       {{- if $nodeSelector }}
       nodeSelector: {{- toYaml $nodeSelector | nindent 8 }}

--- a/charts/kubeclarity/templates/scanner-template-configmap.yaml
+++ b/charts/kubeclarity/templates/scanner-template-configmap.yaml
@@ -6,6 +6,7 @@
 {{- $noproxy = append $noproxy (print ((index .Values "kubeclarity-trivy-server" "service" "name") | default (include "trivy.fullname" (index .Subcharts "kubeclarity-trivy-server"))) "." .Release.Namespace ":" (index .Values "kubeclarity-trivy-server" "service" "port")) -}}
 {{- end -}}
 {{- $affinity := (coalesce (index .Values "kubeclarity-runtime-scan" "affinity") .Values.global.affinity) -}}
+{{- $tolerations := (coalesce (index .Values "kubeclarity-grype-server" "tolerations") .Values.global.tolerations) -}}
 {{- $nodeSelector := (coalesce (index .Values "kubeclarity-runtime-scan" "nodeSelector") .Values.global.nodeSelector) -}}
 apiVersion: v1
 kind: ConfigMap
@@ -30,12 +31,11 @@ data:
           labels:
 {{- toYaml (index .Values "kubeclarity-runtime-scan" "labels") | nindent 12 }}
         spec:
-{{- if (index .Values "kubeclarity-runtime-scan" "tolerations") }}
-          tolerations:
-{{- toYaml (index .Values "kubeclarity-runtime-scan" "tolerations") | nindent 12 }}
-{{- end}}
           {{- if $affinity }}
           affinity: {{- toYaml $affinity | nindent 12 }}
+          {{- end }}
+          {{- if $tolerations }}
+          tolerations: {{- toYaml $tolerations | nindent 8 }}
           {{- end }}
           {{- if $nodeSelector }}
           nodeSelector: {{- toYaml $nodeSelector | nindent 12 }}

--- a/charts/kubeclarity/templates/scanner-template-configmap.yaml
+++ b/charts/kubeclarity/templates/scanner-template-configmap.yaml
@@ -35,7 +35,7 @@ data:
           affinity: {{- toYaml $affinity | nindent 12 }}
           {{- end }}
           {{- if $tolerations }}
-          tolerations: {{- toYaml $tolerations | nindent 8 }}
+          tolerations: {{- toYaml $tolerations | nindent 12 }}
           {{- end }}
           {{- if $nodeSelector }}
           nodeSelector: {{- toYaml $nodeSelector | nindent 12 }}

--- a/charts/kubeclarity/templates/scanner-template-configmap.yaml
+++ b/charts/kubeclarity/templates/scanner-template-configmap.yaml
@@ -6,7 +6,7 @@
 {{- $noproxy = append $noproxy (print ((index .Values "kubeclarity-trivy-server" "service" "name") | default (include "trivy.fullname" (index .Subcharts "kubeclarity-trivy-server"))) "." .Release.Namespace ":" (index .Values "kubeclarity-trivy-server" "service" "port")) -}}
 {{- end -}}
 {{- $affinity := (coalesce (index .Values "kubeclarity-runtime-scan" "affinity") .Values.global.affinity) -}}
-{{- $tolerations := (coalesce (index .Values "kubeclarity-grype-server" "tolerations") .Values.global.tolerations) -}}
+{{- $tolerations := (coalesce (index .Values "kubeclarity-runtime-scan" "tolerations") .Values.global.tolerations) -}}
 {{- $nodeSelector := (coalesce (index .Values "kubeclarity-runtime-scan" "nodeSelector") .Values.global.nodeSelector) -}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -22,6 +22,11 @@ global:
   ## Affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # affinity: {}
+
+  ## Overrides global.tolerations
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  # tolerations: {}
+
   nodeSelector:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
@@ -119,6 +124,10 @@ kubeclarity:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # affinity: {}
 
+  ## Overrides global.tolerations
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  # tolerations: {}
+
   ## Overrides global.nodeSelector
   # nodeSelector:
   #   key1: value1
@@ -163,6 +172,10 @@ kubeclarity-runtime-scan:
   ## Scanner pods Affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # affinity: {}
+
+  ## Overrides global.tolerations
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  # tolerations: {}
 
   registry:
     skipVerifyTlS: "false"
@@ -285,6 +298,10 @@ kubeclarity-grype-server:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # affinity: {}
 
+  ## Overrides global.tolerations
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  # tolerations: {}
+
   ## Overrides global.nodeSelector
   # nodeSelector:
   #   key1: value1
@@ -362,6 +379,10 @@ kubeclarity-sbom-db:
   ## Overrides global.affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # affinity: {}
+
+  ## Overrides global.tolerations
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  # tolerations: {}
 
   ## Overrides global.nodeSelector
   # nodeSelector:

--- a/charts/kubeclarity/values.yaml
+++ b/charts/kubeclarity/values.yaml
@@ -23,7 +23,7 @@ global:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # affinity: {}
 
-  ## Overrides global.tolerations
+  ## Tolerations
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   # tolerations: {}
 


### PR DESCRIPTION
## Description

The current helm chart doesn't allow configuring tolerations.

This is a problem in clusters where you may have tainted nodes which kubeclarity should run on.

Adds an open tolerations value to kubeclarity / sbom / grype to allow arbitrary node / pod affinity configuration.
```yaml
kubeclarity:
  tolerations:
    - key: "nodetype"
      operator: "Equal"
      value: "taintedNode"
      effect: "NoSchedule" 
```


## Type of Change

- [X] New Feature

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass

